### PR TITLE
Mouse click shortcut & Edit Transcription

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-  "svelte.enable-ts-plugin": true
+  "svelte.enable-ts-plugin": true,
+  "rust-analyzer.cargo.extraEnv": {
+        "MACOSX_DEPLOYMENT_TARGET": "14.6"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "super-mouse-ai",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2463,6 +2463,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "mouce"
+version = "0.2.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe3ea1c7bd346cca28cd75d6ebc77b2475bf13c627170843b150e97dd3431122"
+dependencies = [
+ "glob",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "mp4parse"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4209,6 +4219,7 @@ version = "0.1.0"
 dependencies = [
  "audrey",
  "log",
+ "mouce",
  "num",
  "num_cpus",
  "rodio",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4215,7 +4215,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "super-mouse-ai"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "audrey",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,6 +29,7 @@ num_cpus = "1.16.0"
 rodio = { version = "0.20.1" }
 strum = { version = "0.26.2", features = ["derive"] }
 ureq = "3.0.4"
+mouce = "0.2.50"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 # NOTE: CUDA feature separate feature flag

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "super-mouse-ai"
-version = "0.1.0"
+version = "0.2.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ use mouce::{
 use mutter::{Model, ModelError};
 use serde::{Deserialize, Serialize};
 use tauri::{path::BaseDirectory, AppHandle, Emitter, Manager, State};
+use tauri_plugin_global_shortcut::{Code, Modifiers, Shortcut};
 // use webview2_com::Microsoft::Web::WebView2::Win32::{
 //     ICoreWebView2Profile4, ICoreWebView2_13, COREWEBVIEW2_PERMISSION_KIND_MICROPHONE,
 //     COREWEBVIEW2_PERMISSION_STATE_DEFAULT,
@@ -88,9 +89,29 @@ fn listen_for_mouse_click(app_handle: AppHandle) {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    let mod_key = Shortcut::new(Some(Modifiers::ALT), Code::Space);
+
     tauri::Builder::default()
-        .plugin(tauri_plugin_global_shortcut::Builder::new().build())
-        .setup(|app: &mut tauri::App| {
+        .plugin(
+            tauri_plugin_global_shortcut::Builder::new()
+                .with_shortcuts([
+                    // alt_left,
+                    // alt_right,
+                    // ctrl_left,
+                    // ctrl_right,
+                    // shift_left,
+                    // shift_right,
+                    mod_key,
+                ])
+                .expect("Shortcuts should be valid")
+                .with_handler(|app, _shortcut, event| {
+                    app.emit("mod_key_event", event.state)
+                        .expect("Keyboard should emit");
+                })
+                .build(),
+        )
+        .setup(|app| {
+            //  Load the model
             let resource_path = app
                 .path()
                 .resolve("resources/whisper-model.bin", BaseDirectory::Resource)?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,10 @@
+use mouce::{
+    common::{MouseButton, MouseEvent},
+    Mouse, MouseActions,
+};
 use mutter::{Model, ModelError};
-use tauri::{path::BaseDirectory, Manager, State};
+use serde::{Deserialize, Serialize};
+use tauri::{path::BaseDirectory, AppHandle, Emitter, Manager, State};
 // use webview2_com::Microsoft::Web::WebView2::Win32::{
 //     ICoreWebView2Profile4, ICoreWebView2_13, COREWEBVIEW2_PERMISSION_KIND_MICROPHONE,
 //     COREWEBVIEW2_PERMISSION_STATE_DEFAULT,
@@ -48,15 +53,44 @@ fn transcribe(app_state: State<'_, AppState>, audio_data: Vec<u8>) -> Result<Str
     Ok(transcription.as_text())
 }
 
-// TODO: Cannot register mouse click in hotkey directly using the plugin
-//       (see https://github.com/tauri-apps/global-hotkey/issues/50),
-//       consider: https://crabnebula.dev/blog/building-a-desktop-pet-with-tauri/
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+enum MouseButtonType {
+    Left,
+    Middle,
+    Right,
+}
+
+impl From<&MouseButton> for MouseButtonType {
+    fn from(mb: &MouseButton) -> Self {
+        match mb {
+            MouseButton::Left => MouseButtonType::Left,
+            MouseButton::Middle => MouseButtonType::Middle,
+            MouseButton::Right => MouseButtonType::Right,
+        }
+    }
+}
+
+/// Function to listen for any clicks from mouse
+///
+/// Adapted from https://github.com/crabnebula-dev/koi-pond/blob/main/src-tauri/src/lib.rs under MIT License
+fn listen_for_mouse_click(app_handle: AppHandle) {
+    let mut mouse_manager = Mouse::new();
+    mouse_manager
+        .hook(Box::new(move |e| match e {
+            MouseEvent::Press(button) => app_handle
+                .emit("mouse_press", MouseButtonType::from(button))
+                .expect("App Handle should emit press event with button playload"),
+            // MouseEvent::Release(mouse_button) => todo!(),
+            _ => (),
+        }))
+        .expect("Able to listen to mouse clicks!");
+}
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
-        .setup(|app| {
+        .setup(|app: &mut tauri::App| {
             let resource_path = app
                 .path()
                 .resolve("resources/whisper-model.bin", BaseDirectory::Resource)?;
@@ -66,6 +100,7 @@ pub fn run() {
                 .map_err(|os_str| format!("\"{:?}\" cannot be convered to string!", os_str))?;
             let model = Model::new(&model_path)?;
             app.manage(AppState { model });
+            listen_for_mouse_click(app.handle().clone());
             Ok(())
         })
         .plugin(tauri_plugin_opener::init())

--- a/src-tauri/src/transcript.rs
+++ b/src-tauri/src/transcript.rs
@@ -44,6 +44,7 @@ impl Transcript {
 
     /// Returns the transcript in VTT format.
     #[must_use]
+    #[allow(dead_code)] // For now because I don't use vtt feature
     pub fn as_vtt(&self) -> String {
         let vtt = self
             .utterances
@@ -63,6 +64,7 @@ impl Transcript {
 
     /// Returns the transcript in SRT format.
     #[must_use]
+    #[allow(dead_code)] // For now because I don't use srt feature
     pub fn as_srt(&self) -> String {
         self.utterances
             .iter()
@@ -85,6 +87,7 @@ impl Transcript {
 
 /// Timestamp is oddly given in number of seconds * 100, or number of milliseconds / 10.
 /// This function corrects it and formats it in the desired format.
+#[allow(dead_code)] // For now because I don't use format timestamp feature
 fn format_timestamp(num: i64, always_include_hours: bool, decimal_marker: &str) -> String {
     assert!(num >= 0, "non-negative timestamp expected");
     let mut milliseconds: i64 = num * 10;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -44,7 +44,7 @@
       },
       "files": {},
       "hardenedRuntime": true,
-      "minimumSystemVersion": "10.13",
+      "minimumSystemVersion": "14.6",
       "entitlements": "Entitlements.plist"
     },
     "icon": [

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -29,6 +29,7 @@
   let recordingState: null | "stopped" | "recording" | "processing" =
     $state(null);
   let mouseClickCount = $state(0);
+  let modKeyHeld = false;
   // FIXME: Type should not be any
   let audioRecorder: IMediaRecorder | null = $state(null);
   let audioData = $state([]);
@@ -55,6 +56,7 @@
 
   let wavRecorderConnection: MessagePort | undefined;
   let clickEventUnlistener: UnlistenFn;
+  let modEventUnlistener: UnlistenFn;
   // Effects
   $effect(() => {
     // On-Mount
@@ -68,7 +70,12 @@
       });
       clickEventUnlistener = await listen("mouse_press", (e) => {
         console.log(e);
-        mouseClickCount++;
+        if (modKeyHeld) {
+          toggleRecord();
+        }
+      });
+      modEventUnlistener = await listen("mod_key_event", (e) => {
+        modKeyHeld = e.payload === "Pressed";
       });
     };
     // Get user permission to use mircophone
@@ -156,7 +163,6 @@
 
   async function processData() {
     recordingState = "processing";
-    console.log(blobChunks.length);
     const blob =
       blobChunks.length === 1
         ? blobChunks[0]!

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -212,7 +212,7 @@
     <button
       class="p-2 mx-32 my-2 text-sm bg-amber-500 rounded-sm hover:bg-amber-600"
       onclick={resetPermission}
-      disabled={audioRecorder !== null}>Ask Permission Agin</button
+      disabled={audioRecorder !== null}>Ask Permission Again</button
     >
     <section id="audio-holder" class="mx-32 my-4 text-center">
       <button

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -170,9 +170,13 @@
     currentURL = window.URL.createObjectURL(blob);
     audioElement.src = currentURL;
     try {
-      transcribedOutput = await invoke("transcribe", {
-        audioData: await blobToBytes(blob),
-      });
+      transcribedOutput = (
+        (await invoke("transcribe", {
+          audioData: await blobToBytes(blob),
+        })) as string
+      )
+        .trim()
+        .replaceAll("[BLANK_AUDIO]", "");
     } catch (error) {
       alert(`An error occured while transcribing: ${error}`);
     }
@@ -231,15 +235,11 @@
       <audio class="w-full" controls bind:this={audioElement}></audio>
       <p>Mouse Clicks: {mouseClickCount}</p>
     </section>
-    <div class="mx-32 my-4 text-center rounded-md border-4 min-h-32">
-      {#if transcribedOutput}
-        <output>
-          {transcribedOutput}
-        </output>
-      {:else}
-        <em> This is where output goes </em>
-      {/if}
-    </div>
+    <textarea
+      class="mx-32 my-4 text-center rounded-md border-4 min-h-32"
+      placeholder="This is where the output goes"
+      disabled={transcribedOutput === ""}>{transcribedOutput}</textarea
+    >
     <button
       class="p-2 mx-32 my-2 rounded-sm bg-slate-100 hover:bg-slate-200"
       onclick={copyToClipboard}


### PR DESCRIPTION
## Features

1. User can now press `Alt+Space+Left Mouse` to toggle recording
2. User can now edit transcription after processing.

### Known limitations

* Required to have a "real" key (`Space` but could be another) alongside modifier key due to limitation of Global Shortcut plugin (does not register without it)
* Editing text should have a way to reverse changes, in case user makes a bad change (like delete everything). A solution may be to plug into web view undo/redo system 

## Notes

Includes version bump to `0.2.0` (not for build now, but for later)