### PR TITLE
Simplify UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "super-mouse-ai",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4466,7 +4466,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "super-mouse-ai"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "audrey",
  "device_query",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "super-mouse-ai"
-version = "0.4.3"
+version = "0.4.4"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/resources/whisper-model-info.md
+++ b/src-tauri/resources/whisper-model-info.md
@@ -1,0 +1,11 @@
+List of all
+[Whisper.cpp models](https://github.com/ggerganov/whisper.cpp/tree/master/models)
+can be found and downloaded from here:
+
+- <https://huggingface.co/ggerganov/whisper.cpp/tree/main>
+- <https://ggml.ggerganov.com>
+
+Default model must be named `whisper-model.bin` in order to be properly loaded.
+
+Currently used model:
+[`ggml-tiny.en-q5_1.bin`](https://huggingface.co/ggerganov/whisper.cpp/blob/main/ggml-tiny.en-q5_1.bin)

--- a/src-tauri/resources/whisper-model-info.md
+++ b/src-tauri/resources/whisper-model-info.md
@@ -8,4 +8,4 @@ can be found and downloaded from here:
 Default model must be named `whisper-model.bin` in order to be properly loaded.
 
 Currently used model:
-[`ggml-tiny.en-q5_1.bin`](https://huggingface.co/ggerganov/whisper.cpp/blob/main/ggml-tiny.en-q5_1.bin)
+[`ggml-small.en-q5_1.bin`](https://huggingface.co/ggerganov/whisper.cpp/blob/main/ggml-small.en-q5_1.bin)

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "super-mouse-ai",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "identifier": "com.super-mouse-ai.app",
   "build": {
     "beforeDevCommand": "deno task dev",

--- a/src/lib/components/CustomShortcut.svelte
+++ b/src/lib/components/CustomShortcut.svelte
@@ -10,13 +10,21 @@
     import { listen, type UnlistenFn } from "@tauri-apps/api/event";
     import type { NotificationSystem } from "$lib/notificationSystem.svelte";
     import { SvelteSet } from "svelte/reactivity";
+    import type { Snippet } from "svelte";
 
     interface CustomShortcutProps {
         notifier?: NotificationSystem;
         onToggleShortcutEvent: ShortcutHandler;
+        class?: string;
+        description?: Snippet;
     }
 
-    let { notifier, onToggleShortcutEvent }: CustomShortcutProps = $props();
+    let {
+        notifier,
+        onToggleShortcutEvent,
+        class: className = "",
+        description,
+    }: CustomShortcutProps = $props();
 
     type ShowShortcutFn = <T>(shortcut: string, returns: T) => T;
 
@@ -244,7 +252,7 @@
     {#if enabled ?? true}
         <button {onclick}>
             <kbd
-                class={`kbd ${active ? "outline-2 outline-primary" : ""} ${numberOfModKyes > 1 && onclick ? "hover:bg-error" : ""}`}
+                class={`kbd text-xs sm:text-sm ${active ? "outline-2 outline-primary" : ""} ${numberOfModKyes > 1 && onclick ? "hover:bg-error" : ""}`}
                 >{name}</kbd
             >
         </button>
@@ -254,19 +262,21 @@
     {/if}
 {/snippet}
 
-<section>
+<section class="flex justify-center place-center">
     <fieldset
-        class={`fieldset bg-base-200 border border-base-300 p-4 rounded-box ${hasShortcutError ? "border-error" : "border-success"}`}
+        class={`fieldset bg-base-200 border border-base-300 p-4 rounded-box ${hasShortcutError ? "border-error" : "border-success"} ${className}`}
     >
-        <legend class="fieldset-legend">Custom Shortcut</legend>
-        <p class="">
+        <legend class="fieldset-legend">Recording Shortcut</legend>
+        <p class="flex justify-center align-text-top">
             {@render keyboardItem(
                 "Ctrl",
                 false,
                 modCtrl,
                 () => {
-                    if (numberOfModKyes > 1) modCtrl = false;
-                    else {
+                    if (numberOfModKyes > 1) {
+                        modCtrl = false;
+                        setupShortcut();
+                    } else {
                         notifier?.showInfo(
                             "Must have at least one modifer key!",
                         );
@@ -279,8 +289,10 @@
                 false,
                 modShift,
                 () => {
-                    if (numberOfModKyes > 1) modShift = false;
-                    else {
+                    if (numberOfModKyes > 1) {
+                        modShift = false;
+                        setupShortcut();
+                    } else {
                         notifier?.showInfo(
                             "Must have at least one modifer key!",
                         );
@@ -293,8 +305,10 @@
                 false,
                 modAlt,
                 () => {
-                    if (numberOfModKyes > 1) modAlt = false;
-                    else {
+                    if (numberOfModKyes > 1) {
+                        modAlt = false;
+                        setupShortcut();
+                    } else {
                         notifier?.showInfo(
                             "Must have at least one modifer key!",
                         );
@@ -307,8 +321,10 @@
                 false,
                 modSuper,
                 () => {
-                    if (numberOfModKyes > 1) modSuper = false;
-                    else {
+                    if (numberOfModKyes > 1) {
+                        modSuper = false;
+                        setupShortcut();
+                    } else {
                         notifier?.showInfo(
                             "Must have at least one modifer key!",
                         );
@@ -324,16 +340,14 @@
         </p>
         <Button
             id={LISTENER_BUTTON_ID}
-            color={isListening ? "primary" : "neutral"}
-            onclick={toggleListen}>Listen for shortcut</Button
+            color={isListening ? "primary" : "accent"}
+            class="h-4"
+            onclick={toggleListen}
         >
-        <p class="fieldset-label">
-            You can click on modifier keys to remove them. There must always be
-            one main trigger key or mouse click in order to be a valid shortcut.
-        </p>
-        <p class="fieldset-label text-warning">
-            NOTE: Key shown may not map one-to-one if you are using a non-QWERTY
-            keyboard layout.
-        </p>
+            <span class="text-xs"> Listen for new shortcut </span>
+        </Button>
+        <div class="fieldset-label">
+            {@render description?.()}
+        </div>
     </fieldset>
 </section>

--- a/src/lib/components/CustomShortcut.svelte
+++ b/src/lib/components/CustomShortcut.svelte
@@ -340,8 +340,8 @@
         </p>
         <Button
             id={LISTENER_BUTTON_ID}
-            color={isListening ? "primary" : "accent"}
-            class="h-4"
+            color={isListening ? "primary" : "info"}
+            class="h-6"
             onclick={toggleListen}
         >
             <span class="text-xs"> Listen for new shortcut </span>

--- a/src/lib/components/MenuScreen.svelte
+++ b/src/lib/components/MenuScreen.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+    import * as Dialog from "$lib/components/ui/dialog/index.js";
+    import type { Snippet } from "svelte";
+
+    interface MenuScreenProps {
+        open?: boolean;
+        title?: string;
+        description?: string;
+        class?: string;
+        children?: Snippet;
+    }
+
+    let {
+        open = $bindable(false),
+        title = "Menu",
+        description = "Menu for the application",
+        class: className = "",
+        children,
+    }: MenuScreenProps = $props();
+</script>
+
+<Dialog.Root bind:open>
+    <Dialog.Trigger class="fixed top-0 btn btn-secondary btn-soft p-2 m-1"
+        >Open Menu</Dialog.Trigger
+    >
+    <Dialog.Content class={`${className}`}>
+        <div>
+            <Dialog.Title><h2>{title}</h2></Dialog.Title>
+            <Dialog.Description>
+                {description}
+            </Dialog.Description>
+        </div>
+        <div class=" overflow-auto">
+            {@render children?.()}
+        </div>
+    </Dialog.Content>
+</Dialog.Root>

--- a/src/lib/components/MicRecorder.svelte
+++ b/src/lib/components/MicRecorder.svelte
@@ -164,5 +164,4 @@
         {/if}
         {recordingText}
     </p>
-    <hr />
 </section>

--- a/src/lib/components/PermissionBar.svelte
+++ b/src/lib/components/PermissionBar.svelte
@@ -8,6 +8,8 @@
         recordingState: RecordingStates;
         notifier: NotificationSystem;
         testNotify?: boolean;
+        showNames?: boolean;
+        showIcons?: boolean;
     }
 
     let {
@@ -15,6 +17,8 @@
         recordingState,
         notifier,
         testNotify = false,
+        showNames = true,
+        showIcons = true,
     }: PermissionsBarProps = $props();
 
     let explicitMicrophonePermission: PermissionState = $state(
@@ -60,17 +64,17 @@
     >
         <PermissionButton
             name="Microphone"
-            icon="🎤"
+            icon={showIcons ? "🎤" : ""}
             status={microphonePermission}
             onclick={resetPermission}
-            showName={false}
+            showName={showNames}
         />
         <PermissionButton
             name="Notification"
-            icon="🔔"
+            icon={showIcons ? "🔔" : ""}
             status={notificationPermission}
             onclick={() => notifier.getPermissionToNotify(testNotify)}
-            showName={false}
+            showName={showNames}
         />
     </div>
 </div>

--- a/src/lib/components/PermissionBar.svelte
+++ b/src/lib/components/PermissionBar.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+    import { NotificationSystem } from "$lib/notificationSystem.svelte";
+    import { type RecordingStates } from "$lib/types";
+    import PermissionButton from "$lib/components/PermissionButton.svelte";
+
+    interface PermissionsBarProps {
+        setupRecorder: () => Promise<void>;
+        recordingState: RecordingStates;
+        notifier: NotificationSystem;
+        testNotify?: boolean;
+    }
+
+    let {
+        setupRecorder,
+        recordingState,
+        notifier,
+        testNotify = false,
+    }: PermissionsBarProps = $props();
+
+    let explicitMicrophonePermission: PermissionState = $state(
+        "denied" as PermissionState,
+    );
+    let notificationPermission: boolean = $state(false);
+
+    const microphonePermission: boolean | null = $derived(
+        explicitMicrophonePermission === "prompt"
+            ? null
+            : explicitMicrophonePermission === "granted",
+    );
+
+    $effect(() => {
+        const queryPermissions = async () => {
+            notificationPermission = await notifier.checkPermissionGranted();
+            await updateMicrophonePermissions();
+        };
+        queryPermissions();
+    });
+
+    async function updateMicrophonePermissions() {
+        explicitMicrophonePermission =
+            // @ts-ignore 'microphone' should be querable for permissions
+            (await navigator.permissions.query({ name: "microphone" })).state;
+    }
+
+    async function resetPermission() {
+        let devices = await navigator.mediaDevices.enumerateDevices();
+        if (devices.length > 0) {
+            await updateMicrophonePermissions();
+            return;
+        }
+        await setupRecorder();
+        devices = await navigator.mediaDevices.enumerateDevices();
+    }
+</script>
+
+<div>
+    <!-- <h2 class="text-center text-xl">Permissions</h2> -->
+    <div
+        class="grid grid-cols-1 gap-1 md:gap-2 xl:gap-4 sm:grid-cols-2 lg:grid-cols-3 justify-items-center place-items-center"
+    >
+        <PermissionButton
+            name="Microphone"
+            icon="🎤"
+            status={microphonePermission}
+            onclick={resetPermission}
+            showName={false}
+        />
+        <PermissionButton
+            name="Notification"
+            icon="🔔"
+            status={notificationPermission}
+            onclick={() => notifier.getPermissionToNotify(testNotify)}
+            showName={false}
+        />
+    </div>
+</div>

--- a/src/lib/components/PermissionButton.svelte
+++ b/src/lib/components/PermissionButton.svelte
@@ -58,7 +58,7 @@
             <Status color={statusColor} size="lg" class="mr-2" />
         {/if}
         <span class="text-accent">
-            {icon ? `${icon}` : ""}{icon && showName ? ":" : ""}{showName
+            {icon ? `${icon}` : ""}{icon && showName ? ": " : ""}{showName
                 ? name
                 : ""}</span
         >

--- a/src/lib/components/PermissionButton.svelte
+++ b/src/lib/components/PermissionButton.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+    import Button from "$lib/components/ui/button/button.svelte";
+    import Status from "$lib/components/ui/Status.svelte";
+
+    interface PermissionButtonProps {
+        name: string;
+        showName?: boolean;
+        showStatusAsEmoji?: boolean;
+        status?: boolean | null;
+        onclick: () => void;
+        icon?: string;
+    }
+
+    let {
+        name,
+        status,
+        onclick,
+        icon,
+        showName = true,
+        showStatusAsEmoji = false,
+    }: PermissionButtonProps = $props();
+
+    const statusColor = $derived(
+        status === true ? "success" : status === false ? "error" : "warning",
+    );
+    const statusValue = $derived(
+        status === true
+            ? "granted"
+            : status === false
+              ? "denied"
+              : "user prompted",
+    );
+    const statusIcon = $derived(
+        status === true ? "✅" : status === false ? "❌" : "❔",
+    );
+</script>
+
+<div class="tooltip tooltip-bottom" data-tip="">
+    <div class="tooltip-content">
+        <div>
+            <span
+                >{`${name} permission is `}<span class={`text-${statusColor}`}
+                    >{statusValue}</span
+                ></span
+            >
+            {#if status === null}
+                <br />
+                <span class="text-secondary"
+                    >Click button to ask permission.</span
+                >
+            {/if}
+        </div>
+    </div>
+    <Button variant="outline" color={statusColor} {onclick}>
+        {#if showStatusAsEmoji}
+            <span>{statusIcon}</span>
+        {:else}
+            <Status color={statusColor} size="lg" class="mr-2" />
+        {/if}
+        <span class="text-accent">
+            {icon ? `${icon}` : ""}{icon && showName ? ":" : ""}{showName
+                ? name
+                : ""}</span
+        >
+    </Button>
+</div>

--- a/src/lib/components/ui/ThemeDropdown.svelte
+++ b/src/lib/components/ui/ThemeDropdown.svelte
@@ -11,20 +11,24 @@ Component based off of: <https://daisyui.com/components/theme-controller/>
             kind?: "system" | "light" | "dark";
         }[];
         class?: string;
+        listClass?: string;
         current?: "system" | "light" | "dark";
+        direction?: "top" | "bottom" | "left" | "right";
     }
 
     let {
         themes,
         class: className,
+        listClass,
         current = $bindable("system"),
+        direction = "bottom",
     }: ThemeSwitcherProps = $props();
 </script>
 
-<div class={`dropdown z-10 ${className}`}>
+<div class={`dropdown dropdown-${direction} z-10 ${className}`}>
     <div tabindex="0" role="button" class="btn m-1">
-        Theme
-        <svg
+        Theme:<span class="text-accent">{current}</span>
+        <!-- <svg
             width="12px"
             height="12px"
             class="inline-block h-2 w-2 fill-current opacity-60"
@@ -33,10 +37,10 @@ Component based off of: <https://daisyui.com/components/theme-controller/>
         >
             <path d="M1799 349l242 241-1017 1017L7 590l242-241 775 775 775-775z"
             ></path>
-        </svg>
+        </svg> -->
     </div>
     <ul
-        class="dropdown-content bg-base-300 rounded-box z-1 w-52 p-2 shadow-2xl"
+        class={`dropdown-content bg-base-300 rounded-box z-1 shadow-2xl ${listClass}`}
     >
         {#each themes as theme}
             <li>

--- a/src/lib/components/ui/dialog/dialog-content.svelte
+++ b/src/lib/components/ui/dialog/dialog-content.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+    import {
+        Dialog as DialogPrimitive,
+        type WithoutChildrenOrChild,
+    } from "bits-ui";
+    import type { Snippet } from "svelte";
+    import * as Dialog from "./index.js";
+    import { cn } from "$lib/utils.js";
+
+    let {
+        ref = $bindable(null),
+        class: className,
+        portalProps,
+        children,
+        ...restProps
+    }: WithoutChildrenOrChild<DialogPrimitive.ContentProps> & {
+        portalProps?: DialogPrimitive.PortalProps;
+        children: Snippet;
+    } = $props();
+</script>
+
+<Dialog.Portal {...portalProps}>
+    <Dialog.Overlay />
+    <DialogPrimitive.Content
+        bind:ref
+        class={cn(
+            "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] bg-background fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:rounded-lg",
+            className,
+        )}
+        {...restProps}
+    >
+        {@render children?.()}
+        <DialogPrimitive.Close
+            class="btn btn-error absolute top-0 right-0 mt-1 mr-1"
+            >Close
+        </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+</Dialog.Portal>

--- a/src/lib/components/ui/dialog/dialog-description.svelte
+++ b/src/lib/components/ui/dialog/dialog-description.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+    import { Dialog as DialogPrimitive } from "bits-ui";
+    import { cn } from "$lib/utils.js";
+
+    let {
+        ref = $bindable(null),
+        class: className,
+        ...restProps
+    }: DialogPrimitive.DescriptionProps = $props();
+</script>
+
+<DialogPrimitive.Description
+    bind:ref
+    class={cn("text-muted-foreground text-sm", className)}
+    {...restProps}
+/>

--- a/src/lib/components/ui/dialog/dialog-overlay.svelte
+++ b/src/lib/components/ui/dialog/dialog-overlay.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+    import { Dialog as DialogPrimitive } from "bits-ui";
+    import { cn } from "$lib/utils.js";
+
+    let {
+        ref = $bindable(null),
+        class: className,
+        ...restProps
+    }: DialogPrimitive.OverlayProps = $props();
+</script>
+
+<DialogPrimitive.Overlay
+    bind:ref
+    class={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0  fixed inset-0 z-50 bg-black/90",
+        className,
+    )}
+    {...restProps}
+/>

--- a/src/lib/components/ui/dialog/dialog-title.svelte
+++ b/src/lib/components/ui/dialog/dialog-title.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+    import { Dialog as DialogPrimitive } from "bits-ui";
+    import { cn } from "$lib/utils.js";
+
+    let {
+        ref = $bindable(null),
+        class: className,
+        ...restProps
+    }: DialogPrimitive.TitleProps = $props();
+</script>
+
+<DialogPrimitive.Title
+    bind:ref
+    class={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    {...restProps}
+/>

--- a/src/lib/components/ui/dialog/index.ts
+++ b/src/lib/components/ui/dialog/index.ts
@@ -1,0 +1,31 @@
+import { Dialog as DialogPrimitive } from "bits-ui";
+
+import Title from "./dialog-title.svelte";
+import Overlay from "./dialog-overlay.svelte";
+import Content from "./dialog-content.svelte";
+import Description from "./dialog-description.svelte";
+
+const Root = DialogPrimitive.Root;
+const Trigger = DialogPrimitive.Trigger;
+const Close = DialogPrimitive.Close;
+const Portal = DialogPrimitive.Portal;
+
+export {
+    Root,
+    Title,
+    Portal,
+    Trigger,
+    Overlay,
+    Content,
+    Description,
+    Close,
+    //
+    Root as Dialog,
+    Title as DialogTitle,
+    Portal as DialogPortal,
+    Trigger as DialogTrigger,
+    Overlay as DialogOverlay,
+    Content as DialogContent,
+    Description as DialogDescription,
+    Close as DialogClose,
+};

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -11,6 +11,8 @@
   import ThemeDropdown from "$lib/components/ui/ThemeDropdown.svelte";
   import PermissionsPage from "$lib/components/PermissionsPage.svelte";
   import CustomShortcut from "$lib/components/CustomShortcut.svelte";
+  import MenuScreen from "$lib/components/MenuScreen.svelte";
+  import PermissionBar from "$lib/components/PermissionBar.svelte";
 
   const THEMES = [
     {
@@ -89,58 +91,37 @@
 </script>
 
 <main class="">
-  <Toaster position="top-right" richColors closeButton {theme} />
-  <ThemeDropdown themes={THEMES} bind:current={theme} class="fixed top-0" />
+  <MenuScreen>
+    <section class="tabs tabs-lift w-full">
+      <Tab
+        value="tabs"
+        label="Configuration"
+        class="bg-base-100 border-base-300 p-6"
+        checked
+      >
+        <div class="h-60 overflow-auto pr-6">
+          <WhisperOptions bind:threads bind:initialPrompt bind:ignoredWords />
+        </div>
+      </Tab>
+    </section>
+  </MenuScreen>
+  <Toaster position="top-center" richColors closeButton {theme} />
+  <ThemeDropdown
+    themes={THEMES}
+    bind:current={theme}
+    class="fixed top-0 right-0"
+    listClass="p-1 w-full"
+    direction="bottom"
+  />
   <div class="mx-2 sm:mx-24 md:mx-32">
     <h1 class="text-3xl text-center pt-12 sm:pt-0">SuperMouse AI</h1>
+    <PermissionBar
+      setupRecorder={() => micRecorder.setupRecorder()}
+      {recordingState}
+      {notifier}
+      {testNotify}
+    />
     <div class="flex flex-col place-content-center">
-      <section class="tabs tabs-lift">
-        <Button
-          color="destructive"
-          variant="ghost"
-          shape="circle"
-          onclick={() =>
-            document.getElementsByName("tabs").forEach(
-              (tab) =>
-                // @ts-ignore: Every tab is a radio input
-                (tab.checked = false),
-            )}>X</Button
-        >
-        <Tab
-          value="tabs"
-          label="Permissions"
-          checked
-          class="bg-base-100 border-base-300 p-6"
-        >
-          <PermissionsPage
-            setupRecorder={() => micRecorder.setupRecorder()}
-            {recordingState}
-            {notifier}
-            {testNotify}
-          />
-        </Tab>
-        <Tab
-          value="tabs"
-          label="Settings"
-          class="bg-base-100 border-base-300 p-6"
-        >
-          <CustomShortcut
-            onToggleShortcutEvent={(e) => {
-              if (e.state === "Pressed") {
-                micRecorder?.toggleRecording();
-              }
-            }}
-            {notifier}
-          />
-        </Tab>
-        <Tab
-          value="tabs"
-          label="Configuration"
-          class="bg-base-100 border-base-300 p-6"
-        >
-          <WhisperOptions bind:threads bind:initialPrompt bind:ignoredWords />
-        </Tab>
-      </section>
       <MicRecorder
         bind:this={micRecorder}
         {recordingState}
@@ -148,6 +129,16 @@
         {onRecordingEnd}
         {onError}
       />
+      <CustomShortcut
+        class="w-3/4 mb-2"
+        onToggleShortcutEvent={(e) => {
+          if (e.state === "Pressed") {
+            micRecorder?.toggleRecording();
+          }
+        }}
+        {notifier}
+      />
+      <hr />
       <div class="grid grid-cols-2 my-1">
         <Button
           color={recordingState === "processing" ? "neutral" : "warning"}


### PR DESCRIPTION
## Features

- Add new component:
  - Dialog UI based on [Bits UI](https://next.bits-ui.com/docs/components/dialog#api-reference) and [Shadcn-Svelte](https://next.shadcn-svelte.com/docs/components/dialog)
  - Menu Screen
  - Permission Button
  - Permission Bar
- Update existing components
  - Remove `<hr/>` from `MicRecorder`
  - Add directionality for `ThemeDropdown`
  - Reduce information in `CustomShortcut`
- Improve homepage with updated components
  - Remove tabs, now permission bar with simple view of permissions, recording button moved up, move shortcut customizer below button.
  - User should see recording button prominently
  - Theme switcher moved to the right, to allow menu button on the left.
- _Note an update to whisper model_

### Additional Notes

Bump version to **`v0.4.4`**

Related Issue: #17 