### PR TITLE
Store bug fixing: v0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "super-mouse-ai",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "description": "",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4466,7 +4466,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "super-mouse-ai"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "audrey",
  "device_query",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "super-mouse-ai"
-version = "0.4.4"
+version = "0.5.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "super-mouse-ai",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "identifier": "com.super-mouse-ai.app",
   "build": {
     "beforeDevCommand": "deno task dev",

--- a/src/lib/components/AudioTranscriber.svelte
+++ b/src/lib/components/AudioTranscriber.svelte
@@ -26,7 +26,10 @@
                         threads: configStore.threads,
                         initialPrompt: configStore.initialPrompt,
                     })) as string
-                ).trim();
+                )
+                    .trim()
+                    // Replace all "empty" newlines after words
+                    .replaceAll(/(?<=\w)[ \t]*\n/g, " ");
                 for (const word of configStore.ignoredWordsList) {
                     transcribedResult = transcribedResult.replaceAll(word, "");
                 }

--- a/src/lib/components/AudioTranscriber.svelte
+++ b/src/lib/components/AudioTranscriber.svelte
@@ -16,23 +16,18 @@
 
     let workingChunks: Blob[] = $state([]);
 
-    export async function processData(
-        blobChunks?: Blob[],
-        threads?: number,
-        initialPrompt?: string,
-        wordsToIgnore: string[] = [],
-    ) {
+    export async function processData(blobChunks?: Blob[]) {
         try {
             workingChunks = blobChunks ?? workingChunks;
             if (workingChunks.length > 0) {
                 let transcribedResult = (
                     (await invoke("transcribe", {
                         audioData: await blobChunksToBytes(workingChunks),
-                        threads,
-                        initialPrompt,
+                        threads: configStore.threads,
+                        initialPrompt: configStore.initialPrompt,
                     })) as string
                 ).trim();
-                for (const word of wordsToIgnore) {
+                for (const word of configStore.ignoredWordsList) {
                     transcribedResult = transcribedResult.replaceAll(word, "");
                 }
                 configStore.addTranscription(transcribedResult);

--- a/src/lib/components/AudioTranscriber.svelte
+++ b/src/lib/components/AudioTranscriber.svelte
@@ -73,9 +73,16 @@
         variant="ghost"
         color="destructive"
         onclick={() => {
-            notifier?.confirmAction("Are you sure you want to delete?", () => {
-                configStore.removeCurrentTranscription();
-            });
+            notifier?.confirmAction(
+                `You are deleting: ${configStore.currentTranscript.length > 100 ? configStore.currentTranscript.substring(0, 100).trimEnd() + "..." : configStore.currentTranscript}`,
+                () => {
+                    configStore.removeCurrentTranscription();
+                },
+                () => {
+                    notifier?.showInfo("Cancelled delete.", "", "");
+                },
+                "Are you sure you want to delete?",
+            );
         }}
         disabled={configStore.isTranscriptsEmpty}>Delete Current</Button
     >

--- a/src/lib/components/CustomShortcut.svelte
+++ b/src/lib/components/CustomShortcut.svelte
@@ -165,10 +165,12 @@
                 showShortcutUnregistrationError(previousShortcut, null),
             );
         }
-        // For mouse click, don't use Tauri's shortcut system
+        // For mouse click, don't register with Tauri's shortcut system
         if (shortcut.includes("Click")) {
             tauriRegistered = false;
-        } else {
+        }
+        // Check before registering (prevent re-registration error)
+        else if (await isRegistered(shortcut)) {
             await register(shortcut, onToggleShortcutEvent).then(
                 (_success) => {
                     tauriRegistered = true;

--- a/src/lib/components/CustomShortcut.svelte
+++ b/src/lib/components/CustomShortcut.svelte
@@ -11,6 +11,7 @@
     import type { NotificationSystem } from "$lib/notificationSystem.svelte";
     import { SvelteSet } from "svelte/reactivity";
     import type { Snippet } from "svelte";
+    import { configStore } from "$lib/store.svelte";
 
     interface CustomShortcutProps {
         notifier?: NotificationSystem;
@@ -73,15 +74,11 @@
     let modShift: boolean = $state(true);
 
     let modCurrentSet: SvelteSet<string> = new SvelteSet();
-    let mainKey: string = $state("KeyR");
     let isListening: boolean = $state(false);
     let tauriRegistered: boolean = $state(false);
     const LISTENER_BUTTON_ID = "shortcut-listener";
     let previousShortcut = $state("");
 
-    const shortcut = $derived(
-        `${modCtrl ? "Control+" : ""}${modShift ? "Shift+" : ""}${modAlt ? "Alt+" : ""}${modSuper ? "Super+" : ""}${mainKey}`,
-    );
     const numberOfModKyes = $derived(
         +modCtrl + +modShift + +modAlt + +modSuper,
     );
@@ -110,7 +107,7 @@
         modSuper = event.metaKey;
         const keycode = event.code;
         if (!keycode || EXCLUDED_MAIN_KEYS.includes(keycode)) return;
-        mainKey = keycode;
+        configStore.shortcut = formatShortcutWith(keycode);
     }
 
     function mouseNumberToText(button: number): string {
@@ -124,6 +121,10 @@
             return "RightClick";
         }
         return `MouseButton${button + 1}Click`;
+    }
+
+    function formatShortcutWith(mainKey: string) {
+        return `${modCtrl ? "Control+" : ""}${modShift ? "Shift+" : ""}${modAlt ? "Alt+" : ""}${modSuper ? "Super+" : ""}${mainKey}`;
     }
 
     function onMouseDown(event: MouseEvent) {
@@ -140,16 +141,20 @@
         modCtrl = event.ctrlKey;
         modShift = event.shiftKey;
         modSuper = event.metaKey;
-        mainKey = mouseNumberToText(event.button);
+        configStore.shortcut = formatShortcutWith(
+            mouseNumberToText(event.button),
+        );
     }
 
     function toggleListen() {
+        // Set previous shortcut before starting to listen
         if (!isListening) {
-            previousShortcut = shortcut;
+            previousShortcut = configStore.shortcut;
         }
         isListening = !isListening;
+        // Register after finish listening
         if (!isListening) {
-            setupShortcut(previousShortcut !== shortcut);
+            setupShortcut(previousShortcut !== configStore.shortcut);
         }
     }
 
@@ -166,19 +171,32 @@
             );
         }
         // For mouse click, don't register with Tauri's shortcut system
-        if (shortcut.includes("Click")) {
+        if (configStore.shortcut.includes("Click")) {
             tauriRegistered = false;
+        } else {
+            // Check before registering (prevent re-registration error)
+            try {
+                const isShortcutReg = await isRegistered(configStore.shortcut);
+                if (!isShortcutReg)
+                    await register(
+                        configStore.shortcut,
+                        onToggleShortcutEvent,
+                    ).then(
+                        (_success) => {
+                            tauriRegistered = true;
+                        },
+                        (_failure) =>
+                            showShortcutRegistrationError(
+                                configStore.shortcut,
+                                null,
+                            ),
+                    );
+            } catch (error) {
+                showShortcutFindingError(configStore.shortcut, false);
+                return;
+            }
         }
-        // Check before registering (prevent re-registration error)
-        else if (await isRegistered(shortcut)) {
-            await register(shortcut, onToggleShortcutEvent).then(
-                (_success) => {
-                    tauriRegistered = true;
-                },
-                (_failure) => showShortcutRegistrationError(shortcut, null),
-            );
-        }
-        showShortcutRegistrationSuccess(shortcut, null);
+        showShortcutRegistrationSuccess(configStore.shortcut, null);
     }
 
     let clickEventUnlistener: UnlistenFn | null = null;
@@ -202,7 +220,10 @@
             clickEventUnlistener = await listen("mouse_press", (p) => {
                 if (isListening || tauriRegistered) return;
                 const payload = p.payload as string;
-                if (checkAllModPressed() && mainKey.includes(payload)) {
+                if (
+                    checkAllModPressed() &&
+                    configStore.shortcut.includes(payload)
+                ) {
                     onToggleShortcutEvent({
                         shortcut: "MouseClick",
                         id: 0,
@@ -226,6 +247,7 @@
                     modCurrentSet.delete(key);
                 }
             });
+            await configStore.waitForStoreLoaded();
             setupShortcut(previousShortcut === "");
         };
         asyncSetup();
@@ -277,7 +299,7 @@
                 () => {
                     if (numberOfModKyes > 1) {
                         modCtrl = false;
-                        setupShortcut();
+                        setupShortcut(true);
                     } else {
                         notifier?.showInfo(
                             "Must have at least one modifer key!",
@@ -293,7 +315,7 @@
                 () => {
                     if (numberOfModKyes > 1) {
                         modShift = false;
-                        setupShortcut();
+                        setupShortcut(true);
                     } else {
                         notifier?.showInfo(
                             "Must have at least one modifer key!",
@@ -309,7 +331,7 @@
                 () => {
                     if (numberOfModKyes > 1) {
                         modAlt = false;
-                        setupShortcut();
+                        setupShortcut(true);
                     } else {
                         notifier?.showInfo(
                             "Must have at least one modifer key!",
@@ -325,7 +347,7 @@
                 () => {
                     if (numberOfModKyes > 1) {
                         modSuper = false;
-                        setupShortcut();
+                        setupShortcut(true);
                     } else {
                         notifier?.showInfo(
                             "Must have at least one modifer key!",
@@ -335,7 +357,7 @@
                 true,
             )}
             {@render keyboardItem(
-                mainKey.replace(/([a-z0-9])([A-Z])/g, "$1 $2"),
+                configStore.mainKey.replace(/([a-z0-9])([A-Z])/g, "$1 $2"),
                 false,
                 true,
             )}

--- a/src/lib/components/PermissionBar.svelte
+++ b/src/lib/components/PermissionBar.svelte
@@ -2,12 +2,12 @@
     import { NotificationSystem } from "$lib/notificationSystem.svelte";
     import { type RecordingStates } from "$lib/types";
     import PermissionButton from "$lib/components/PermissionButton.svelte";
+    import { configStore } from "$lib/store.svelte";
 
     interface PermissionsBarProps {
         setupRecorder: () => Promise<void>;
         recordingState: RecordingStates;
         notifier: NotificationSystem;
-        testNotify?: boolean;
         showNames?: boolean;
         showIcons?: boolean;
     }
@@ -16,7 +16,6 @@
         setupRecorder,
         recordingState,
         notifier,
-        testNotify = false,
         showNames = true,
         showIcons = true,
     }: PermissionsBarProps = $props();
@@ -73,7 +72,8 @@
             name="Notification"
             icon={showIcons ? "🔔" : ""}
             status={notificationPermission}
-            onclick={() => notifier.getPermissionToNotify(testNotify)}
+            onclick={() =>
+                notifier.getPermissionToNotify(configStore.testNotify)}
             showName={showNames}
         />
     </div>

--- a/src/lib/components/PermissionsPage.svelte
+++ b/src/lib/components/PermissionsPage.svelte
@@ -3,20 +3,16 @@
     import { type RecordingStates } from "$lib/types";
     import { NotificationSystem } from "$lib/notificationSystem.svelte";
     import Status from "$lib/components/ui/Status.svelte";
+    import { configStore } from "$lib/store.svelte";
 
     interface PermissionsPageProps {
         setupRecorder: () => Promise<void>;
         recordingState: RecordingStates;
         notifier: NotificationSystem;
-        testNotify?: boolean;
     }
 
-    let {
-        setupRecorder,
-        recordingState,
-        notifier,
-        testNotify = false,
-    }: PermissionsPageProps = $props();
+    let { setupRecorder, recordingState, notifier }: PermissionsPageProps =
+        $props();
 
     let explicitMicrophonePermission: PermissionState = $state(
         "denied" as PermissionState,
@@ -105,7 +101,7 @@
         "Notification",
         notificationPermission,
         notificationPermission,
-        () => notifier.getPermissionToNotify(testNotify),
+        () => notifier.getPermissionToNotify(configStore.testNotify),
         "🔔",
     )}
 </div>

--- a/src/lib/components/WhisperOptions.svelte
+++ b/src/lib/components/WhisperOptions.svelte
@@ -1,20 +1,16 @@
 <script lang="ts">
+    import { configStore } from "$lib/store.svelte";
+
     interface WhisperOptionProps {
-        threads?: number;
         translate?: boolean;
         individualWordTimestamps?: boolean;
-        initialPrompt?: string;
         language?: string;
-        ignoredWords?: string[];
     }
 
     let {
-        threads = $bindable(0),
         translate = $bindable(),
         individualWordTimestamps = $bindable(),
-        initialPrompt = $bindable(),
         language = $bindable("en"),
-        ignoredWords = $bindable(),
     }: WhisperOptionProps = $props();
 </script>
 
@@ -26,7 +22,7 @@
         name="threads"
         id="threads-option"
         min="0"
-        bind:value={threads}
+        bind:value={configStore.threads}
         class="p-1 rounded-sm border-1"
     />
     <p class="fieldset-label">0 = Use all, otherwise, limited to number</p>
@@ -38,7 +34,7 @@
         name="prompt"
         id="promt-option"
         placeholder="Using default prompt."
-        bind:value={initialPrompt}
+        bind:value={configStore.initialPrompt}
         class="p-1 rounded-sm border-1 w-full"
     />
     <p class="fieldset-label">Can use to define style or fix spelling.</p>
@@ -51,10 +47,7 @@
         placeholder="List of words to ignore."
         class="p-1 rounded-sm border-1 w-full"
         rows={5}
-        bind:value={() => ignoredWords?.join("\n") || "",
-        (words) => {
-            ignoredWords = words.split("\n").map((w) => w.trim());
-        }}
+        bind:value={configStore.ignoredWords}
     ></textarea>
     <p class="fieldset-label">
         Specify words to ignore (define each on new line)

--- a/src/lib/notificationSystem.svelte.ts
+++ b/src/lib/notificationSystem.svelte.ts
@@ -29,7 +29,7 @@ export class NotificationSystem {
         requestPermission().then(permission => {
             this.#permissionGranted = permission === "granted";
             if (testNotify && this.#permissionGranted) {
-                sendNotification("Notification Test!");
+                sendNotification("Notification are enabled!");
             } else if (testNotify) {
                 window.alert("Notification not enabled!");
             }
@@ -115,7 +115,7 @@ export class NotificationSystem {
         confirmButtonStyle: string = "btn btn-success",
         cancelButtonStyle: string = "btn btn-error",
     ) {
-        toast.warning(`${subtitle ? subtitle + ": " : ""}${message}`, {
+        toast.warning(subtitle ? subtitle : message, {
             duration: Number.POSITIVE_INFINITY, action: {
                 label: confirm,
                 onClick: onConfirm,
@@ -127,6 +127,7 @@ export class NotificationSystem {
             },
             cancelButtonStyle,
             important: true,
+            description: subtitle ? message : undefined,
         });
         this.playSound(sound);
     }

--- a/src/lib/store.svelte.ts
+++ b/src/lib/store.svelte.ts
@@ -9,20 +9,35 @@ const AUTO_SAVE_FREQUENCY: false | number = 2000;
  * and decouple from string representation.
  */
 export const ConfigItem = {
+    VERSION: "version",
     THEME: "theme",
     TRANSCRIPTS: "transcripts",
     INDEX: "index",
+    SHORTCUT: "shortcut",
+    THREADS: "threads",
+    PROMPT: "prompt",
+    IGNORED_WORDS: "ignored",
+    SOUND: "sound",
+    TEST_NOTIFY: "notify_on_load",
+
 }
 
 export class ConfigStore {
     // Store items
     fileStore: Store | null = null;
     cleanup: () => void;
+    #version = 1;
 
     // Private Config data
     #theme: ThemeKind = $state("system");
     #transcriptions: string[] = $state([]);
     #currentIndex: number = $state(0);
+    #shortcut = $state("")
+    #threads = $state(1)
+    #enableSound = $state(true);
+    #testNotify = $state(true);
+    #initialPrompt = $state("")
+    #ignoredWords = $state("[BLANK_AUDIO]\n[NO_AUDIO]\n[SILENCE]");
 
     // Derived values
     transcriptLength = $derived(this.#transcriptions.length);
@@ -47,10 +62,19 @@ export class ConfigStore {
     /** Load all items from store for states */
     private async loadAll() {
         if (!this.fileStore) return;
+        this.#version = await this.fileStore.get(ConfigItem.VERSION) ?? this.#version;
         this.#theme = await this.fileStore.get(ConfigItem.THEME) ?? this.#theme;
         this.#transcriptions = await this.fileStore.get(ConfigItem.TRANSCRIPTS) ?? this.#transcriptions;
         this.#currentIndex = await this.fileStore.get(ConfigItem.INDEX) ?? this.#currentIndex;
+        this.#enableSound = await this.fileStore.get(ConfigItem.SOUND) ?? this.#enableSound;
+        this.#testNotify = await this.fileStore.get(ConfigItem.TEST_NOTIFY) ?? this.#testNotify;
+        this.#initialPrompt = await this.fileStore.get(ConfigItem.PROMPT) ?? this.#initialPrompt;
+        this.#ignoredWords = await this.fileStore.get(ConfigItem.IGNORED_WORDS) ?? this.#ignoredWords;
         console.log(await this.fileStore.entries());
+    }
+
+    get version(): number {
+        return this.#version;
     }
 
     get theme(): ThemeKind {
@@ -103,6 +127,83 @@ export class ConfigStore {
         if (this.#currentIndex >= this.transcriptLength - 1) return;
         this.#currentIndex++;
         this.fileStore?.set(ConfigItem.INDEX, this.#currentIndex);
+    }
+
+    get shortcut(): string {
+        return this.#shortcut
+    }
+
+    get mainKey(): string {
+        // NOTE: A main key will alawy exist for a valid shortcut
+        return this.#shortcut.split("+").at(-1)!;
+    }
+
+    get modifierKeys(): {
+        hasAlt: boolean,
+        hasControl: boolean,
+        hasShift: boolean,
+        hasSuper: boolean,
+    } {
+        return {
+            hasAlt: this.#shortcut.includes("Alt"),
+            hasControl: this.#shortcut.includes("Control"),
+            hasShift: this.#shortcut.includes("Shift"),
+            hasSuper: this.#shortcut.includes("Super"),
+        }
+    }
+
+    set shortcut(newShortcut: string) {
+        this.#shortcut = newShortcut;
+        this.fileStore?.set(ConfigItem.SHORTCUT, this.#shortcut);
+    }
+
+    get thread(): number {
+        return this.#threads
+    }
+
+    set thread(newCount: number) {
+        this.#threads = newCount;
+        this.fileStore?.set(ConfigItem.THREADS, this.#threads);
+    }
+
+    get enabledSound(): boolean {
+        return this.#enableSound
+    }
+
+    set enabledSound(enabled: boolean) {
+        this.#enableSound = enabled;
+        this.fileStore?.set(ConfigItem.SOUND, this.#enableSound);
+    }
+
+    get testNotify(): boolean {
+        return this.#testNotify
+    }
+
+    set testNotify(willNotify: boolean) {
+        this.#testNotify = willNotify;
+        this.fileStore?.set(ConfigItem.TEST_NOTIFY, this.#testNotify);
+    }
+
+    get initialPrompt(): string {
+        return this.#initialPrompt
+    }
+
+    set initialPrompt(newPrompt: string) {
+        this.#initialPrompt = newPrompt;
+        this.fileStore?.set(ConfigItem.PROMPT, this.#initialPrompt);
+    }
+
+    get ignoredWords(): string {
+        return this.#ignoredWords;
+    }
+
+    get ignoredWordsList(): string[] {
+        return this.#ignoredWords.split("\n");
+    }
+
+    set ignoredWords(newIgnored: string) {
+        this.#ignoredWords = newIgnored;
+        this.fileStore?.set(ConfigItem.IGNORED_WORDS, this.#ignoredWords);
     }
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -19,11 +19,6 @@
   let audioTranscriber: AudioTranscriber;
   // State
   let recordingState: RecordingStates = $state("stopped");
-  let enableSound = $state(true);
-  let testNotify = $state(true);
-  let threads = $state(0);
-  let initialPrompt = $state("");
-  let ignoredWords = $state(["[BLANK_AUDIO]", "[NO_AUDIO]", "[SILENCE]"]);
   let hasRecorded = $state(false);
 
   // Inner Variables
@@ -31,8 +26,8 @@
     // | This is required to ignore the
     // | state_referenced_locally warning
     // V
-    (() => enableSound)(),
-    (() => testNotify)(),
+    (() => configStore.enabledSound)(),
+    (() => configStore.testNotify)(),
   );
 
   // Helper Functions
@@ -47,12 +42,7 @@
     // Force a microtask to allow rendering before transcribing,
     // fixes issue with "processing" state not updating during processing
     new Promise((resolve) => requestAnimationFrame(resolve)).finally(() => {
-      audioTranscriber.processData(
-        chunks,
-        threads > 0 ? threads : undefined,
-        initialPrompt || undefined,
-        ignoredWords,
-      );
+      audioTranscriber.processData(chunks);
     });
   }
 
@@ -94,7 +84,7 @@
         checked
       >
         <div class="h-60 overflow-auto pr-6">
-          <WhisperOptions bind:threads bind:initialPrompt bind:ignoredWords />
+          <WhisperOptions />
         </div>
       </Tab>
     </section>
@@ -116,7 +106,6 @@
       setupRecorder={() => micRecorder.setupRecorder()}
       {recordingState}
       {notifier}
-      {testNotify}
     />
     <div class="flex flex-col place-content-center">
       <MicRecorder

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -87,6 +87,30 @@
           <WhisperOptions />
         </div>
       </Tab>
+      <Tab
+        value="tabs"
+        label="Danger Zone"
+        inputClass="input-ghost p-6 hover:bg-error checked:input-xl checked:text-warning"
+        class="bg-base-100 border-base-300 p-6"
+      >
+        <div class="h-60 overflow-auto pr-6">
+          <div
+            class="tooltip tooltip-right"
+            data-tip="Click to delete all configuration data."
+          >
+            <Button
+              color="destructive"
+              onclick={() =>
+                notifier.confirmAction(
+                  "You will clear all transcriptions alongside any customizations you have made. This will take effect AFTER closing the app.",
+                  () => configStore.clearData(),
+                  () => {},
+                  "Are you sure?",
+                )}>Clear App Data</Button
+            >
+          </div>
+        </div>
+      </Tab>
     </section>
   </MenuScreen>
   <Toaster


### PR DESCRIPTION
## Feature

- Update config store with additional state values. Now includes more configurable values like CPU thread, initial prompt, ignored words, custom shortcuts, and more.
- Modify components to use those additional state values in-place of inner state values. Allows user to save their customizations.
- Create a tab to delete all customizations if needed (mostly for reverting back to factory defaults).

### Issues to address later

- Cannot delete individual options.
- When deleting customizations, the actual values don't take affect until after the app closes (because state does not react to clearing of keys).
- Toast confirmation message is small, may need to change how that is created.
