### PR TITLE
Bug and lint fixing (v0.6.2)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,45 @@
+{
+    "lint": {
+      "include": ["src/"],
+      "exclude": ["src/lib/bindings.ts", "src/lib/utils.ts"],
+      "rules": {
+        "tags": ["recommended", "jsr"],
+        "include": 
+        [ "eqeqeq"
+        , "explicit-function-return-type"
+        , "explicit-module-boundary-types"
+        , "guard-for-in"
+        , "default-param-last"
+        , "camelcase"
+        , "no-await-in-loop"
+        , "no-boolean-literal-for-arguments"
+        , "no-const-assign"
+        , "no-eval"
+        , "no-implicit-declare-namespace-export"
+        , "no-inferrable-types"
+        , "no-non-null-assertion"
+        , "no-external-import"
+        , "no-non-null-asserted-optional-chain"
+        , "no-self-compare"
+        , "no-sparse-arrays"
+        , "no-sync-fn-in-async-fn"
+        , "no-throw-literal"
+        , "no-top-level-await"
+        , "no-useless-rename"
+        , "prefer-ascii"
+        , "single-var-declarator"
+        , "triple-slash-reference"
+        , "ban-untagged-todo"
+        ],
+        "exclude": ["no-unused-vars"]
+      }
+    },
+    "compilerOptions": {
+      "checkJs": true,
+      "strict": true
+    },
+    "unstable": [
+      "sloppy-imports"
+    ]
+  }
+  

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "super-mouse-ai",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4778,7 +4778,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "super-mouse-ai"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "audrey",
  "device_query",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "super-mouse-ai"
-version = "0.6.1"
+version = "0.6.2"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/src/command.rs
+++ b/src-tauri/src/command.rs
@@ -41,10 +41,10 @@ pub async fn transcribe(
             options.individual_word_timestamps.unwrap_or(false),
             options.initial_prompt.as_deref(),
             options.language.as_deref(),
-            // Make sure not to pass <=0 for CPU thread,
+            // Make sure not to pass 0 for CPU thread,
             // otherwise model crashes
             match options.threads {
-                Some(t) if t <= 0 => None,
+                Some(0) => None,
                 threads => threads,
             },
         )
@@ -174,8 +174,8 @@ pub fn paste_text() -> Result<(), String>{
 #[specta::specta]
 /// Put window on top, can be overriden by optional parameter
 pub async fn set_window_top(webview_window: tauri::WebviewWindow, override_value: Option<bool>) -> Result<(), String> {
-  Ok(webview_window.set_always_on_top(override_value.unwrap_or(true)).map_err(|err| {
+  webview_window.set_always_on_top(override_value.unwrap_or(true)).map_err(|err| {
     log::error!("Could not set window to top value: {}", err);
     err.to_string()
-  })?)
+  })
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -157,7 +157,7 @@ pub fn run() {
             listen_for_mouse_click(app.handle().clone())?;
             let app_key_listener_handler = app.handle().clone();
             // Listen for mod keys directly and emit when found
-            let _ = tauri::async_runtime::spawn_blocking(move || {
+            std::mem::drop(tauri::async_runtime::spawn_blocking(move || {
                 use device_query::{DeviceEvents, DeviceEventsHandler};
                 use std::time::Duration;
 
@@ -178,8 +178,8 @@ pub fn run() {
                         .emit(&app_handle_down)
                         .map_err(|err| log::error!("Error for mod key event press: {err}"));
                 });
-                loop {}
-            });
+                std::thread::yield_now();
+            }));
             Ok(())
         })
         .plugin(tauri_plugin_opener::init())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -178,7 +178,9 @@ pub fn run() {
                         .emit(&app_handle_down)
                         .map_err(|err| log::error!("Error for mod key event press: {err}"));
                 });
-                std::thread::yield_now();
+                // Require loop to ensure thread remains active
+                #[allow(clippy::empty_loop)]
+                loop {}
             }));
             Ok(())
         })

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,7 +11,7 @@ use std::{collections::HashMap, path::PathBuf};
 
 use command::{
     listen_for_mouse_click, paste_text, play_sound, process_text, set_window_top, transcribe,
-    transcribe_with_post_process,
+    transcribe_with_post_process, write_text,
 };
 use mutter::Model;
 use tauri::{path::BaseDirectory, Manager};
@@ -60,7 +60,8 @@ pub fn run() {
             paste_text,
             process_text,
             transcribe_with_post_process,
-            set_window_top
+            set_window_top,
+            write_text
         ])
         .events(collect_events![MouseClickEvent, ModKeyEvent]);
     #[cfg(debug_assertions)] // <- Only export on non-release builds

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -103,7 +103,9 @@ pub fn is_modkey(key: &device_query::Keycode) -> bool {
 pub enum TranscriptionFormat {
     #[default]
     Text,
+    #[allow(clippy::upper_case_acronyms)]
     SRT,
+    #[allow(clippy::upper_case_acronyms)]
     VTT,
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "super-mouse-ai",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "identifier": "com.super-mouse-ai.app",
   "build": {
     "beforeDevCommand": "deno task dev",

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -72,6 +72,17 @@ async setWindowTop(overrideValue: boolean | null) : Promise<Result<null, string>
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
+},
+/**
+ * Paste text from clipboard
+ */
+async writeText(text: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("write_text", { text }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
 }
 }
 

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -32,9 +32,9 @@ async playSound(soundName: string) : Promise<Result<null, string>> {
 /**
  * Paste text from clipboard
  */
-async pasteText(text: string) : Promise<Result<null, string>> {
+async pasteText() : Promise<Result<null, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("paste_text", { text }) };
+    return { status: "ok", data: await TAURI_INVOKE("paste_text") };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };

--- a/src/lib/components/AppOptions.svelte
+++ b/src/lib/components/AppOptions.svelte
@@ -21,21 +21,33 @@
 </fieldset>
 <fieldset class="fieldset bg-base-200 border border-base-300 p-4 rounded-box">
     <ToggleSwitch
-        label="Remove Inter-space Newlines:"
-        bind:checked={configStore.interNLRemove.value}
-    />
-    <p class="fieldset-label">
-        Will remove extra new-lines that happen inside a sentence (between words
-        without puncuation).
-    </p>
-</fieldset>
-<fieldset class="fieldset bg-base-200 border border-base-300 p-4 rounded-box">
-    <ToggleSwitch
         label="Auto-Paste:"
         bind:checked={configStore.autoPaste.value}
     />
     <p class="fieldset-label">
         Immediately paste the value after transcribing (in active area selected
         by cursor).
+    </p>
+</fieldset>
+<fieldset class="fieldset bg-base-200 border border-base-300 p-4 rounded-box">
+    <ToggleSwitch
+        label="Use Ctrl+V for auto-paste:"
+        bind:checked={configStore.pasteViaKeys.value}
+    />
+    <p class="text-base-content/60">
+        When toggled on, auto-paste with <kbd class="kbd kbd-sm text-accent"
+            >Ctrl + V</kbd
+        >. When off, it will write the text (NOTE: uses
+        <kbd class="kbd kbd-sm text-accent">Enter</kbd> for newlines)
+    </p>
+</fieldset>
+<fieldset class="fieldset bg-base-200 border border-base-300 p-4 rounded-box">
+    <ToggleSwitch
+        label="Remove Inter-space Newlines:"
+        bind:checked={configStore.interNLRemove.value}
+    />
+    <p class="fieldset-label">
+        Will remove extra new-lines that happen inside a sentence (between words
+        without puncuation).
     </p>
 </fieldset>

--- a/src/lib/components/DangerZone.svelte
+++ b/src/lib/components/DangerZone.svelte
@@ -2,6 +2,12 @@
     import { notifier } from "$lib/notificationSystem.svelte";
     import { configStore } from "$lib/store.svelte";
     import { Button } from "./ui/button";
+
+    interface DangerZoneProps {
+        isDialogOpen?: boolean;
+    }
+
+    let { isDialogOpen = $bindable(false) }: DangerZoneProps = $props();
 </script>
 
 <div
@@ -10,13 +16,15 @@
 >
     <Button
         color="destructive"
-        onclick={() =>
+        onclick={() => {
+            isDialogOpen = false;
             notifier.confirmAction(
                 "You will clear all transcriptions!",
                 () => configStore.clearTranscripts(),
                 () => {},
                 "Are you sure?",
-            )}>Delete All Transcripts</Button
+            );
+        }}>Delete All Transcripts</Button
     >
 </div>
 <br />
@@ -26,12 +34,14 @@
 >
     <Button
         color="destructive"
-        onclick={() =>
+        onclick={() => {
+            isDialogOpen = false;
             notifier.confirmAction(
                 "You will clear all transcriptions alongside any customizations you have made. This will take effect AFTER closing the app.",
                 () => configStore.clearData(),
                 () => {},
                 "Are you sure?",
-            )}>Clear App Data</Button
+            );
+        }}>Clear App Data</Button
     >
 </div>

--- a/src/lib/components/ui/textarea/index.ts
+++ b/src/lib/components/ui/textarea/index.ts
@@ -1,7 +1,7 @@
 import Root from "./textarea.svelte";
-import TextAreaColor from "./textarea.svelte"
-import TextAreaVariant from "./textarea.svelte"
-import TextAreaSize from "./textarea.svelte"
+import type TextAreaColor from "./textarea.svelte"
+import type TextAreaVariant from "./textarea.svelte"
+import type TextAreaSize from "./textarea.svelte"
 
 type FormTextareaEvent<T extends Event = Event> = T & {
     currentTarget: EventTarget & HTMLTextAreaElement;

--- a/src/lib/myUtils.ts
+++ b/src/lib/myUtils.ts
@@ -10,8 +10,8 @@ export async function blobToBytes(blob: Blob): Promise<Uint8Array> {
 /**
    * Convert a blob to array of bytes with a given type
    */
-export async function blobChunksToBytes(chunks: Blob[], type = "audio/wav"): Promise<Uint8Array> {
-    const blob = chunks.length === 1 ? chunks[0]! : new Blob(chunks, { type: type });
+export function blobChunksToBytes(chunks: Blob[], type = "audio/wav"): Promise<Uint8Array> {
+    const blob = chunks.length === 1 ? chunks[0] : new Blob(chunks, { type: type });
     return blobToBytes(blob);
 
 }

--- a/src/lib/notificationSystem.svelte.ts
+++ b/src/lib/notificationSystem.svelte.ts
@@ -5,8 +5,8 @@ import {
     sendNotification,
 } from "@tauri-apps/plugin-notification";
 import { toast, type ExternalToast } from "svelte-sonner";
-import { commands } from "./bindings";
-import { configStore } from './store.svelte';
+import { commands } from "./bindings.ts";
+import { configStore } from './store.svelte.ts';
 
 
 export const toastData: ExternalToast = {
@@ -28,11 +28,11 @@ export class NotificationSystem {
     #permissionGranted = false;
     #enabledSound = true;
 
-    get permissionGranted() {
+    get permissionGranted(): boolean {
         return this.#permissionGranted
     }
 
-    async checkPermissionGranted() {
+    async checkPermissionGranted(): Promise<boolean> {
         this.#permissionGranted = await isPermissionGranted();
         return this.#permissionGranted
     }
@@ -42,13 +42,13 @@ export class NotificationSystem {
         if (includeSystemNotification) this.getPermissionToNotify(testNotify);
     }
 
-    getPermissionToNotify(testNotify = false) {
+    getPermissionToNotify(testNotify = false): void {
         requestPermission().then(permission => {
             this.#permissionGranted = permission === "granted";
             if (testNotify && this.#permissionGranted) {
                 sendNotification("Notification are enabled!");
             } else if (testNotify) {
-                window.alert("Notification not enabled!");
+                globalThis.alert("Notification not enabled!");
             }
         })
     }
@@ -57,7 +57,7 @@ export class NotificationSystem {
         message: string,
         subtitle = "",
         sound = "default_alert",
-    ) {
+    ): void {
         if (this.#permissionGranted) {
             sendNotification({
                 title: `SuperMouse AI${subtitle ? ": " + subtitle : ""}`,
@@ -69,6 +69,9 @@ export class NotificationSystem {
         this.playSound(sound);
     }
 
+
+    // FIXME: Move subtitle to end
+    // deno-lint-ignore default-param-last
     showToast(message: string, subtitle = "", type?: "info" | "warn" | "error" | "success" | "loading" | "default", sound = "", duration = 5000): string | number {
         // This would be fixed it TS allowed switch/match-expression
         const toster =
@@ -86,10 +89,10 @@ export class NotificationSystem {
 
     showPromiseToast<T>(
         promise: Promise<T>,
-        loading: string = "Loading...",
+        loading = "Loading...",
         success: string | ((data: T) => string) = "Success!",
         error: string | ((error: unknown) => string) = "Error!",
-        final?: () => void | Promise<void>
+        final: (() => void | Promise<void>) | undefined = undefined
     ): string | number | undefined {
         return toast.promise(promise, { ...toastData, loading, success, error, finally: final })
     }
@@ -100,7 +103,7 @@ export class NotificationSystem {
         subtitle = "",
         sound = "",
         duration = 5000,
-    ) {
+    ): void {
         toast.success(subtitle || message, {
             description: subtitle ? message : "",
             duration
@@ -114,7 +117,7 @@ export class NotificationSystem {
         subtitle = "",
         sound = "default_alert",
         duration = 5000,
-    ) {
+    ): void {
         toast.error(subtitle || message, {
             description: subtitle ? message : "",
             duration
@@ -128,7 +131,7 @@ export class NotificationSystem {
         subtitle = "",
         sound = "default_alert",
         duration = 5000,
-    ) {
+    ): void {
         toast.info(subtitle || message, {
             description: subtitle ? message : "",
             duration
@@ -140,7 +143,7 @@ export class NotificationSystem {
         message: string,
         subtitle = "",
         sound = "default_alert",
-    ) {
+    ): void {
         console.log(`Alert ${subtitle}: ${message}`)
         toast(`${subtitle ? subtitle + ": " : ""}${message}`);
         this.playSound(sound);
@@ -151,12 +154,12 @@ export class NotificationSystem {
         onConfirm: () => void,
         onCancel: () => void = () => { },
         subtitle = "",
-        confirm: string = "Yes",
-        cancel: string = "No",
+        confirm = "Yes",
+        cancel = "No",
         sound = "default_alert",
-        confirmButtonStyle: string = "btn btn-success",
-        cancelButtonStyle: string = "btn btn-error",
-    ) {
+        confirmButtonStyle = "btn btn-success",
+        cancelButtonStyle = "btn btn-error",
+    ): void {
         toast.warning(subtitle ? subtitle : message, {
             duration: Number.POSITIVE_INFINITY, action: {
                 label: confirm,
@@ -174,13 +177,13 @@ export class NotificationSystem {
         this.playSound(sound);
     }
 
-    playSound(sound = "default_alert") {
+    playSound(sound = "default_alert"): void {
         if (this.#enabledSound && sound) {
             commands.playSound(sound).catch(err => warn(err))
         }
     }
 
-    setEnabledSound(value: boolean | "toggle") {
+    setEnabledSound(value: boolean | "toggle"): void {
         if (value === "toggle") {
             this.#enabledSound = !this.#enabledSound;
         }

--- a/src/lib/store.svelte.ts
+++ b/src/lib/store.svelte.ts
@@ -25,6 +25,7 @@ export const ConfigItem = {
     FLOAT_WINDOW: "window_always_on_top",
     INTER_SENTENCE_NEWLINE_REMOVE: "remove_newline_inside_sentence",
     AUTO_PASTE: "paste_after_transcribe",
+    PASTE_VIA_KEYBOARD: "use_keys_to_paste",
 }
 
 class StoreStateOption<T> {
@@ -82,6 +83,7 @@ export class ConfigStore {
     windowFloat = new StoreStateOption<boolean>(false, ConfigItem.FLOAT_WINDOW);
     interNLRemove = new StoreStateOption<boolean>(true, ConfigItem.INTER_SENTENCE_NEWLINE_REMOVE);
     autoPaste = new StoreStateOption<boolean>(true, ConfigItem.AUTO_PASTE);
+    pasteViaKeys = new StoreStateOption<boolean>(true, ConfigItem.PASTE_VIA_KEYBOARD);
 
     /** Array of all fields in class that are configuration optiosn */
     #configFields = [

--- a/src/lib/store.svelte.ts
+++ b/src/lib/store.svelte.ts
@@ -1,5 +1,5 @@
-import { load, Store } from '@tauri-apps/plugin-store';
-import type { ThemeKind } from './types';
+import { load, type Store } from '@tauri-apps/plugin-store';
+import type { ThemeKind } from './types.ts';
 import type { UnlistenFn } from '@tauri-apps/api/event';
 import { warn } from '@tauri-apps/plugin-log';
 
@@ -37,13 +37,13 @@ class StoreStateOption<T> {
         this.#name = name;
     }
 
-    async loadFrom(store: Store) {
+    async loadFrom(store: Store): Promise<void> {
         this.#config = store;
         const value = await this.#config.get<T>(this.#name);
         if (value !== undefined) this.#value = value
     }
 
-    async saveToStore() {
+    async saveToStore(): Promise<void> {
         await this.#config?.set(this.#name, this.#value)
     }
 
@@ -105,7 +105,8 @@ export class ConfigStore {
     isTranscriptsEmpty = $derived(this.transcriptions.value.length === 0);
     currentTranscript = $derived(this.transcriptions.value[this.currentIndex.value]);
     ignoredWordsList = $derived(this.ignoredWords.value.split("\n"));
-    // NOTE: A main key will alawy exist for a valid shortcut
+    // NOTE: A main key will alway exist for a valid shortcut
+    // deno-lint-ignore no-non-null-assertion
     mainKey = $derived(this.shortcut.value.split("+").at(-1)!);
     modifierKeys = $derived({
         hasAlt: this.shortcut.value.includes("Alt"),
@@ -114,7 +115,7 @@ export class ConfigStore {
         hasSuper: this.shortcut.value.includes("Super"),
     })
 
-    #isReady: boolean = false;
+    #isReady = false;
     constructor() {
         this.cleanup = $effect.root(() => {
             $effect(() => {
@@ -133,15 +134,16 @@ export class ConfigStore {
     }
 
     /** Wait until store is loaded */
-    async waitForStoreLoaded() {
+    async waitForStoreLoaded(): Promise<void> {
         // HACK: Works, but would be better to follow actual loading resolve
         while (!this.#isReady) {
+            // deno-lint-ignore no-await-in-loop
             await new Promise(resolve => setTimeout(resolve, 100));
         }
     }
 
     /** Load all items from store for states */
-    private async loadAll() {
+    private async loadAll(): Promise<void> {
         if (!this.fileStore) return;
         if (!this.fileStore.has(ConfigItem.VERSION)) {
             await this.fileStore.set(ConfigItem.VERSION, this.#version);
@@ -149,9 +151,10 @@ export class ConfigStore {
         else {
             this.#version = await this.fileStore.get(ConfigItem.VERSION) ?? this.#version;
         }
+        const store = this.fileStore;
         // Load all config from file store
         await Promise.allSettled(
-            this.#configFields.map(field => field.loadFrom(this.fileStore!))
+            this.#configFields.map(field => field.loadFrom(store))
         ).catch((err) => {
             warn("Failed to load from store with given error: ", err)
         })
@@ -159,19 +162,19 @@ export class ConfigStore {
         console.dir(await this.fileStore.entries());
     }
 
-    async saveAll() {
+    saveAll(): Promise<PromiseSettledResult<void>[]> {
         return Promise.allSettled(
             this.#configFields.map(field => field.saveToStore())
         )
     }
 
-    clearTranscripts() {
+    clearTranscripts(): void {
         this.fileStore?.delete(ConfigItem.TRANSCRIPTS);
         this.currentIndex.value = 0;
         this.transcriptions.value = []
     }
 
-    clearData() {
+    clearData(): void {
         this.fileStore?.reset()
     }
 
@@ -181,30 +184,30 @@ export class ConfigStore {
         return this.#version;
     }
 
-    addTranscription(transcript: string) {
+    addTranscription(transcript: string): void {
         // HACK: Issue with proxing array in classes, don't fully understand why yet
         this.transcriptions.value = [...this.transcriptions.value, transcript];
         this.currentIndex.value = this.transcriptLength - 1;
     }
 
-    editTranscription(edited: string) {
+    editTranscription(edited: string): void {
         // HACK: Issue with proxing array in classes, don't fully understand why yet
         this.transcriptions.value = this.transcriptions.value.map((original, index) => index === this.currentIndex.value ? edited : original)
     }
 
-    removeCurrentTranscription() {
+    removeCurrentTranscription(): void {
         // HACK: Issue with proxing array in classes, don't fully understand why yet
         this.transcriptions.value = this.transcriptions.value.filter((_, i) => i !== this.currentIndex.value)
         if (this.currentIndex.value >= this.transcriptLength) this.currentIndex.value = this.transcriptLength - 1;
         if (this.isTranscriptsEmpty) this.currentIndex.value = 0;
     }
 
-    prevIndex() {
+    prevIndex(): void {
         if (this.currentIndex.value <= 0) return;
         this.currentIndex.value--;
     }
 
-    nextIndex() {
+    nextIndex(): void {
         if (this.currentIndex.value >= this.transcriptLength - 1) return;
         this.currentIndex.value++;
     }

--- a/src/params/dev.ts
+++ b/src/params/dev.ts
@@ -1,10 +1,10 @@
-// TODO: Need to have this prevent building when not `dev`
+// TODO(eventually): Need to have this prevent building when not `dev`
 
 import { dev } from '$app/environment';
 import type { ParamMatcher } from '@sveltejs/kit';
 
 const nameOfRoute = "tests";
 
-export const match: ParamMatcher = (param) => {
+export const match: ParamMatcher = (param: string): boolean => {
     return dev && param.includes(nameOfRoute);
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -23,6 +23,7 @@
   // State
   let recordingState: RecordingStates = $state("stopped");
   let hasRecorded = $state(false);
+  let menuOpen = $state(false);
 
   // Helper Functions
   function copyToClipboard() {
@@ -72,7 +73,7 @@
 </script>
 
 <main class="">
-  <MenuScreen>
+  <MenuScreen bind:open={menuOpen}>
     <section class="tabs tabs-lift w-full">
       <Tab
         value="tabs"
@@ -102,7 +103,7 @@
         class="bg-base-100 border-base-300 p-6"
       >
         <div class="h-60 overflow-auto pr-6">
-          <DangerZone />
+          <DangerZone bind:isDialogOpen={menuOpen} />
         </div>
       </Tab>
     </section>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -57,7 +57,13 @@
     notifier.showNotification("Transcription Finished!", "", "finish");
     copyToClipboard();
     if (configStore.autoPaste.value) {
-      commands.pasteText().catch((err) => notifier.showError(err));
+      if (configStore.pasteViaKeys.value) {
+        commands.pasteText().catch((err) => notifier.showError(err));
+      } else {
+        commands
+          .writeText(configStore.currentTranscript)
+          .catch((err) => notifier.showError(err));
+      }
     }
   }
   function onError(err: string) {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -56,9 +56,7 @@
     notifier.showNotification("Transcription Finished!", "", "finish");
     copyToClipboard();
     if (configStore.autoPaste.value) {
-      commands
-        .pasteText(configStore.currentTranscript)
-        .catch((err) => notifier.showError(err));
+      commands.pasteText().catch((err) => notifier.showError(err));
     }
   }
   function onError(err: string) {

--- a/src/routes/tests/+page.ts
+++ b/src/routes/tests/+page.ts
@@ -1,7 +1,17 @@
-// TODO: Need to have this prevent building when not `dev`
+// TODO(eventually): Need to have this prevent building when not `dev`
 import { dev } from '$app/environment';
 
-export const load = () => {
+export type PageLoadType = {
+    status: number;
+    error: string;
+    tests?: undefined;
+} | {
+    tests: string[];
+    status?: undefined;
+    error?: undefined;
+};
+
+export const load = (): PageLoadType => {
     if (!dev) {
         return {
             status: 404,

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,14 +1,14 @@
 import { defineConfig } from "vite";
 import { sveltekit } from "@sveltejs/kit/vite";
 import tailwindcss from '@tailwindcss/vite';
+import process from "node:process";
 
-// @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;
 
 // https://vitejs.dev/config/
 // NOTE: TS Error out with addition of Tailwind plugin,
 // but it still work correctly when run.
-export default defineConfig(async () => ({
+export default defineConfig(() => ({
   plugins: [
     tailwindcss(),
     sveltekit(),


### PR DESCRIPTION
## Features

- Add pasting via `Ctrl+V` (or `Cmd+V` for Mac)
- Add option to toggle between direct style and writing style pasting

## Fixes

- Fix Deno, Cargo, and Clippy lint issues
- Close menu when for confirmation toast to be clickable