### PR TITLE
Absolute Path HTML fix

### DIFF
--- a/.github/workflows/windows-simple-build.yml
+++ b/.github/workflows/windows-simple-build.yml
@@ -20,14 +20,6 @@ jobs:
             args: ""
             name: "cpu-only"
             type: "cpu"
-          - platform: "windows-latest"
-            args: "--features vulkan,no-overlay"
-            name: "vulkan-no-overlay"
-            type: "gpu"
-          - platform: "windows-latest"
-            args: "--features no-overlay"
-            name: "cpu-only-no-overlay"
-            type: "cpu"
 
     runs-on: ${{ matrix.platform }}
     steps:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "super-mouse-ai",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5182,7 +5182,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "super-mouse-ai"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "audrey",
  "device_query",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "super-mouse-ai"
-version = "0.7.1"
+version = "0.7.2"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "super-mouse-ai",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "identifier": "com.super-mouse-ai.app",
   "build": {
     "beforeDevCommand": "deno task dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -28,6 +28,7 @@
         "decorations": false,
         "alwaysOnTop": true,
         "maximized": true,
+        "shadow": false,
         "url": "overlay/"
       }
     ],

--- a/src/app.html
+++ b/src/app.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <link rel="icon" href="%sveltekit.assets%/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Tauri + SvelteKit + Typescript App</title>
+    <title>Super Mouse AI</title>
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,0 +1,3 @@
+<h1>Landing Page only: Click link to go to actual pages</h1>
+<a href="./app">Go to App</a>
+<a href="./overlay">Go to Overlay</a>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -9,9 +9,9 @@ const config = {
   preprocess: vitePreprocess(),
   kit: {
     adapter: adapter(),
-    output: {
-      bundleStrategy: "inline"
-    }
+    paths: {
+      relative: false
+    },
   },
 };
 

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -9,6 +9,9 @@ const config = {
   preprocess: vitePreprocess(),
   kit: {
     adapter: adapter(),
+    output: {
+      bundleStrategy: "inline"
+    }
   },
 };
 


### PR DESCRIPTION
**Expected App Version Number**: `v0.7.2` (Patch)

## Pull Request Overview

- Fixes issue where build output used relative path, which gave the wrong path for files. Use absolute paths now as the fix.
- Fix name of app in front-end

### Known Issues

_"None known at this time"_

## Resolved Issues

_`N/A`_

## Additional Information

- Attempted Inline strategy, but it caused Tailwind to be bundled with overlay (despite not being on its path), causing the screen to be opaque
