### PR TITLE
ci: :construction_worker: Make OpenMP feature explicit for build

### DIFF
--- a/.github/workflows/windows-simple-build.yml
+++ b/.github/workflows/windows-simple-build.yml
@@ -13,11 +13,11 @@ jobs:
       matrix:
         include:
           - platform: "windows-latest"
-            args: "--features vulkan"
+            args: "--features vulkan,openmp"
             name: "vulkan"
             type: "gpu"
           - platform: "windows-latest"
-            args: ""
+            args: "--features openmp"
             name: "cpu-only"
             type: "cpu"
 


### PR DESCRIPTION
**Expected App Version Number**: `v0.7.2` (Keep Same)

## Pull Request Overview

- Make OpenMP flag explicit for build

### Known Issues

_"None known at this time"_

## Resolved Issues

_`N/A`_

## Additional Information

It is possible that the CI build did not build with OpenMP enabled, so make it explicit to make sure
