### PR TITLE
Make telemetry optional (v0.8.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
 ### ⚙️ Miscellaneous Tasks
 
 - Updater now goes to v0.8.6
+- :bookmark: Bump to v0.8.7
 
 ## [0.8.6] - 2025-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,46 @@ All notable changes to this project will be documented in this file.
 
 ### 🚀 Features
 
+- *(backend)* :chart_with_upwards_trend: Make sure PII is disabled
+- *(frontend)* :building_construction: Optional telemetry crash report
+- *(frontend)* :sparkles: Connect crash report updater function
+- *(backend)* :technologist: Auto-open devtools for debug builds
+
+### 🐛 Bug Fixes
+
+- *(frontend)* :bug: Fix circular dependency
+- *(backend)* :bug: Add manage code for sentry plugin
+- *(backend)* :bug: Fix Sentry plugin not loading
+- *(frontend)* :bug: Fix transciption and crash report loading
+- *(frontend)* :bug: Fix crash report not being set on app load
+
+### 🚜 Refactor
+
+- *(backend)* :building_construction: Move sentry plugin into command
+- *(backend)* :technologist: Show name of plugin in log
+- *(frontend)* :mute: Remove old console.log for suitable model sorting
+- *(backend)* :recycle: Different way to disable crash report
+- *(backend)* :recycle: Run minidump only in debug mode
+- *(frontend)* :speech_balloon: Update crash report toggle's label and text
+
+### ⚙️ Miscellaneous Tasks
+
+- Updater now goes to v0.8.6
+
+## [0.8.6] - 2025-05-02
+
+### 🚀 Features
+
 - *(frontend)* :children_crossing: Add a update check button when up to date
 - *(frontend)* :sparkles: Improve permission toggle
+- *(installer)* :sparkles: Create Windows Installer helper
 
 ### 🚜 Refactor
 
 - *(overlay)* :recycle: Use Tauri's cursor position
 - *(backend)* :recycle: Enforce single segment transcription
 - *(frontend)* :recycle: Enable individual word timestamp
+- *(installer)* :recycle: Remove the need for powershell
 
 ### ⚙️ Miscellaneous Tasks
 
@@ -24,6 +56,8 @@ All notable changes to this project will be documented in this file.
 - :construction_worker: Comment out windows simple build workflow
 - *(frontend)* :heavy_plus_sign: Add Tipex editor library
 - :bento: Add new app icon
+- :memo: Update CHANGELOG for v0.8.6
+- *(backend)* :rotating_light: Fix clippy lint issues
 
 ## [0.8.5] - 2025-04-25
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A way to trascribe your voice using Whisper from the click of your mouse.
   - [mutter](https://github.com/sigaloid/mutter): Project that wraps
     `whisper-rs`, directly imported into the project and used under the
     `MIT OR Apache-2.0` license.
+  - [nnnoiseless](https://github.com/jneem/nnnoiseless): Local Audio Denoise
 - [JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript)/[TypeScript](https://www.typescriptlang.org):
   Frontend language
   - [Deno](https://deno.com): Runtime
@@ -24,6 +25,9 @@ A way to trascribe your voice using Whisper from the click of your mouse.
   - [extendable-media-recorder](https://github.com/chrisguttandin/extendable-media-recorder):
     An extendable drop-in replacement for the native MediaRecorder, used to help
     record user voice to WAV for transcription.
+- Misc.
+  - [Sentry](https://sentry.io/welcome/): Error/Crash Tracking
+  - [Git-Cliff](https://git-cliff.org): Changelog Generator
 
 ## License
 
@@ -38,8 +42,8 @@ This project is licensed under either of
 
 at your option.
 
-After 2 years from first commit in this repository, the project will be made
-available under `MIT OR Apache-2.0` licenses. Prior to the 2 years, you may not
-sell the software without explicit grant from the author. For any
-non-commerical/private uses, you may treat the repository as if it were made
-available under the `MIT OR Apache-2.0` licenses.
+For each version of the software, after 2 years from that release, project
+commits up to that point will be made available under `MIT OR Apache-2.0`
+licenses. Prior to the 2 years, you may not sell the software without explicit
+grant from the author. For any non-commerical/private uses, you may treat the
+repository as if it were made available under the `MIT OR Apache-2.0` licenses.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "super-mouse-ai",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5694,7 +5694,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "super-mouse-ai"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "audrey",
  "device_query",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "super-mouse-ai"
 repository = "https://github.com/SurajSSingh/SuperMouseAI"
-version = "0.8.6"
+version = "0.8.7"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/src/command.rs
+++ b/src-tauri/src/command.rs
@@ -440,6 +440,7 @@ pub fn sentry_crash_reporter_update(app_handle: AppHandle, plugin_state: State<'
         
         let sentry_plugin = tauri_plugin_sentry::init(&client);
         state.0.replace(sentry_plugin.name());
+        debug!("State of plugin name: {:?}", state.0);
         app_handle.plugin(sentry_plugin).map_err(|err| err.to_string())?;
         debug!("Finish Sentry Setup");
     } else {

--- a/src-tauri/src/command.rs
+++ b/src-tauri/src/command.rs
@@ -13,17 +13,18 @@ use crate::{
     },
     mutter::ModelError,
     types::{
-        AppState, AudioProcessingOptions, MouseButtonType, SentryPluginInfoState, SystemInfo, TextProcessOptions, TranscribeOptions
+        AppState, AudioProcessingOptions, MouseButtonType, SystemInfo, TextProcessOptions,
+        TranscribeOptions,
     },
+    utils::change_send_to_sentry,
 };
 use enigo::{Enigo, Keyboard, Settings};
 use log::{debug, error, info, trace};
 use mouce::{common::MouseEvent, Mouse, MouseActions};
 use rodio::{Decoder, OutputStream, Sink};
-use tauri_plugin_sentry::{minidump, sentry};
-use std::{fs::File, io::BufReader, sync::Arc};
+use std::{fs::File, io::BufReader};
 use sysinfo::{CpuRefreshKind, MemoryRefreshKind, RefreshKind, System};
-use tauri::{plugin::Plugin, AppHandle, State, Wry};
+use tauri::{AppHandle, State, Wry};
 use tauri_specta::{collect_commands, Commands, Event};
 
 #[tauri::command]
@@ -405,52 +406,8 @@ pub async fn get_system_info() -> SystemInfo {
 #[tauri::command]
 #[specta::specta]
 /// Initialize/De-initialize the sentry plugin depending on the toggled value
-pub fn sentry_crash_reporter_update(app_handle: AppHandle, plugin_state: State<'_, SentryPluginInfoState>, enable: bool) -> Result<(), String>{
-    let mut state = plugin_state.lock().map_err(|err| err.to_string())?;
-    if enable && state.0.is_none()  {
-        debug!("Start Sentry Setup");
-        let client = 
-        sentry::init((
-            "https://e48c5c52c4ca1341de4618624cc0f511@o4509002112958464.ingest.us.sentry.io/4509007972007936",
-            sentry::ClientOptions {
-                release: sentry::release_name!(),
-                auto_session_tracking: true,
-                send_default_pii: false,
-                before_send: Some(Arc::new(|mut event| {
-                    // Remove IP Address, Server name, and Email if it is still provided
-                    event.server_name = None;
-                    event.user.as_mut().map(|user| {
-                        user.ip_address = None;
-                        user.email = None;
-                    });
-                    Some(event)
-                })),
-                ..Default::default()
-            },
-        ));
-        debug!("Sentry Configured");
-        // Caution! Everything before here runs in both app and crash reporter processes
-        #[cfg(not(target_os = "ios"))]
-        let _guard = minidump::init(&client);
-        // let _ = tauri::async_runtime::spawn_blocking(move || {
-        //     let _g = guard;
-        //     loop {}
-        // });
-        debug!("Minidump Configured");
-        
-        let sentry_plugin = tauri_plugin_sentry::init(&client);
-        state.0.replace(sentry_plugin.name());
-        debug!("State of plugin name: {:?}", state.0);
-        app_handle.plugin(sentry_plugin).map_err(|err| err.to_string())?;
-        debug!("Finish Sentry Setup");
-    } else {
-        if let Some(plugin) = state.0 {
-            debug!("Start removing Sentry");
-            app_handle.remove_plugin(plugin);
-            state.0.take();
-            debug!("Finish removing Sentry");
-        }
-    }
+pub async fn sentry_crash_reporter_update(enable: bool) -> Result<(), String> {
+    change_send_to_sentry(enable);
     Ok(())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,8 +11,8 @@ use std::sync::Arc;
 use std::{collections::HashMap, path::PathBuf};
 use tauri::{path::BaseDirectory, Manager};
 use tauri::{App, AppHandle};
+use tauri_plugin_sentry::sentry;
 use tauri_plugin_sentry::sentry::ClientInitGuard;
-use tauri_plugin_sentry::{minidump, sentry};
 use tauri_specta::{Builder, Event};
 
 // Internal Modules
@@ -69,8 +69,8 @@ pub fn run() {
     info!("Start app building");
     let client = create_sentry_client();
     // Caution! Everything before here runs in both app and crash reporter processes
-    #[cfg(not(target_os = "ios"))]
-    let _guard = minidump::init(&client);
+    #[cfg(all(not(target_os = "ios"), debug_assertions))]
+    let _guard = tauri_plugin_sentry::minidump::init(&client);
     debug!("Finish Sentry Setup");
     // Everything after here runs in only the app process
     let app_builder = create_app_builder(&client);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,7 +22,7 @@ mod types;
 use command::listen_for_mouse_click;
 use events::ModKeyEvent;
 use mutter::Model;
-use types::{is_modkey, InnerAppState, ModKeyPayload};
+use types::{is_modkey, InnerAppState, InnerSentryPluginInfoState, ModKeyPayload};
 
 pub use crate::command::get_collected_commands;
 pub use crate::events::get_collected_events;
@@ -165,6 +165,7 @@ fn setup_app(app: &App, bindings_builder: &Builder) -> Result<(), Box<dyn std::e
     let sound_map = create_sound_map(app)?;
     debug!("Finished creating sound map");
     app.manage(std::sync::Mutex::new(InnerAppState::new(model, sound_map)));
+    app.manage(std::sync::Mutex::new(InnerSentryPluginInfoState(None)));
     trace!("Created initial app state");
     debug!("Setup mouse click listener");
     let _mouse_click_listener_handler = listen_for_mouse_click(app.handle().clone())?;

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -241,3 +241,9 @@ pub struct AudioProcessingOptions {
     /// Value for high pass filter, this represents minimum frequency allowed, default is `200`
     pub high_pass_value: Option<u32>,
 }
+
+#[derive(Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, Type)]
+/// Data to hold information about sentry plugin
+pub struct InnerSentryPluginInfoState(pub Option<&'static str>);
+
+pub type SentryPluginInfoState = std::sync::Mutex<InnerSentryPluginInfoState>;

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -241,9 +241,3 @@ pub struct AudioProcessingOptions {
     /// Value for high pass filter, this represents minimum frequency allowed, default is `200`
     pub high_pass_value: Option<u32>,
 }
-
-#[derive(Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, Type)]
-/// Data to hold information about sentry plugin
-pub struct InnerSentryPluginInfoState(pub Option<&'static str>);
-
-pub type SentryPluginInfoState = std::sync::Mutex<InnerSentryPluginInfoState>;

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -1,0 +1,13 @@
+/// A global state representing whether we can send with Sentry
+pub static SEND_TO_SENTRY: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(cfg!(debug_assertions));
+
+pub const ORDERING: std::sync::atomic::Ordering = std::sync::atomic::Ordering::SeqCst;
+
+pub fn will_send_to_sentry() -> bool {
+    SEND_TO_SENTRY.load(ORDERING)
+}
+
+pub fn change_send_to_sentry(val: bool) {
+    SEND_TO_SENTRY.store(val, ORDERING);
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "super-mouse-ai",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "identifier": "com.super-mouse-ai.app",
   "build": {
     "beforeDevCommand": "deno task dev",

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -100,6 +100,17 @@ async updateModel(path: string | null, useGpu: boolean | null) : Promise<Result<
  */
 async getSystemInfo() : Promise<SystemInfo> {
     return await TAURI_INVOKE("get_system_info");
+},
+/**
+ * Initialize/De-initialize the sentry plugin depending on the toggled value
+ */
+async sentryCrashReporterUpdate(enable: boolean) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("sentry_crash_reporter_update", { enable }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
 }
 }
 
@@ -109,13 +120,11 @@ async getSystemInfo() : Promise<SystemInfo> {
 export const events = __makeEvents__<{
 modKeyEvent: ModKeyEvent,
 mouseClickEvent: MouseClickEvent,
-mouseMoveEvent: MouseMoveEvent,
 transcriptionProgressEvent: TranscriptionProgressEvent,
 transcriptionSegmentEvent: TranscriptionSegmentEvent
 }>({
 modKeyEvent: "mod-key-event",
 mouseClickEvent: "mouse-click-event",
-mouseMoveEvent: "mouse-move-event",
 transcriptionProgressEvent: "transcription-progress-event",
 transcriptionSegmentEvent: "transcription-segment-event"
 })
@@ -175,15 +184,6 @@ export type MouseButtonType = "Left" | "Middle" | "Right"
  */
 export type MouseClickEvent = MouseButtonType
 /**
- * Tauri event representing mouse movement
- * 
- * ### Payload
- * 
- * x [i32] : Absolute X value of mosue (from 0 to `SCREEN_WIDTH`)
- * y [i32] : Absolute Y value of mouse (from 0 to `SCREEN_HEIGHT`)
- */
-export type MouseMoveEvent = { x: number; y: number }
-/**
  * Basic information about the current system
  */
 export type SystemInfo = { 
@@ -229,6 +229,12 @@ export type TranscribeOptions = { translate: boolean | null; individual_word_tim
  */
 export type TranscriptionFormat = "Text" | "SRT" | "VTT"
 /**
+ * Tauri event representing mouse movement
+ * 
+ * ### Payload
+ * 
+ * x [i32] : Absolute X value of mosue (from 0 to `SCREEN_WIDTH`)
+ * y [i32] : Absolute Y value of mouse (from 0 to `SCREEN_HEIGHT`)
  * Event representing the progress for the current transcription
  * 
  * ### Payload

--- a/src/lib/components/AppOptions.svelte
+++ b/src/lib/components/AppOptions.svelte
@@ -4,6 +4,8 @@
     import { emit } from "@tauri-apps/api/event";
     import CollapseableFieldSet from "./ui/CollapseableFieldSet.svelte";
     import ToggleSwitch from "./ui/ToggleSwitch.svelte";
+    import { notifier } from "$lib/notificationSystem.svelte";
+    import { error } from "@tauri-apps/plugin-log";
 
     interface AppOptionProps {}
 
@@ -63,7 +65,9 @@
             label="Crash Report:"
             bind:checked={
                 () => configStore.enableCrashReport.value === true,
-                (v) => (configStore.enableCrashReport.value = v)
+                (v) => {
+                    configStore.updateCrashReporter(v);
+                }
             }
             indeterminate={configStore.enableCrashReport.value === null}
             disabled={true}

--- a/src/lib/components/AppOptions.svelte
+++ b/src/lib/components/AppOptions.svelte
@@ -66,11 +66,17 @@
             bind:checked={
                 () => configStore.enableCrashReport.value === true,
                 (v) => {
-                    configStore.updateCrashReporter(v);
+                    configStore.updateCrashReporter(v).then((err) => {
+                        if (err) {
+                            notifier.showToast(
+                                `Error in changing Sentry option: ${err}`,
+                                "error",
+                            );
+                        }
+                    });
                 }
             }
             indeterminate={configStore.enableCrashReport.value === null}
-            disabled={true}
         />
         <p class="fieldset-label">
             Allow running telemetry for app issues and crash reports.

--- a/src/lib/components/AppOptions.svelte
+++ b/src/lib/components/AppOptions.svelte
@@ -60,15 +60,16 @@
     </div>
     <div class="mb-4">
         <ToggleSwitch
-            label="Telemetry:"
-            bind:checked={configStore.enableTelemetry.value}
+            label="Crash Report:"
+            bind:checked={
+                () => configStore.enableCrashReport.value === true,
+                (v) => (configStore.enableCrashReport.value = v)
+            }
+            indeterminate={configStore.enableCrashReport.value === null}
             disabled={true}
         />
         <p class="fieldset-label">
-            To allow running telemetry for app issues and crash reports. <span
-                class="text-warning"
-                >This is cannot be disabled for pre-release builds.</span
-            >
+            Allow running telemetry for app issues and crash reports.
         </p>
     </div>
 </CollapseableFieldSet>

--- a/src/lib/components/AppOptions.svelte
+++ b/src/lib/components/AppOptions.svelte
@@ -62,7 +62,7 @@
     </div>
     <div class="mb-4">
         <ToggleSwitch
-            label="Crash Report:"
+            label="Send Crash Report:"
             bind:checked={
                 () => configStore.enableCrashReport.value === true,
                 (v) => {
@@ -79,7 +79,11 @@
             indeterminate={configStore.enableCrashReport.value === null}
         />
         <p class="fieldset-label">
-            Allow running telemetry for app issues and crash reports.
+            Allow sending telemetry data for app issues and crash reports to
+            help development.
+            <span class="text-warning"
+                >No personal data like audio or transcripts are collected.</span
+            >
         </p>
     </div>
 </CollapseableFieldSet>

--- a/src/lib/myUtils.ts
+++ b/src/lib/myUtils.ts
@@ -196,12 +196,8 @@ export function findLargestUseableModel(
     return null;
   }
   // Get the smallest model that works
-  console.log(suitableModels.sort((a, b) => a.approxSize - b.approxSize));
-  console.log(
-    suitableModels.sort((a, b) => getQuantPriority(b) - getQuantPriority(a)),
-  );
-  console.log(
-    suitableModels.sort((a, b) => getModelPriority(b) - getModelPriority(a)),
-  );
+  suitableModels.sort((a, b) => a.approxSize - b.approxSize);
+  suitableModels.sort((a, b) => getQuantPriority(b) - getQuantPriority(a));
+  suitableModels.sort((a, b) => getModelPriority(b) - getModelPriority(a));
   return suitableModels.at(0) || null;
 }

--- a/src/lib/store.svelte.ts
+++ b/src/lib/store.svelte.ts
@@ -9,7 +9,6 @@ import { debug, error, info, trace, warn } from "@tauri-apps/plugin-log";
 import { open } from "@tauri-apps/plugin-fs";
 import { BASE_LOCAL_APP_DIR } from "./constants.ts";
 import { commands } from "./bindings.ts";
-import { notifier } from "./notificationSystem.svelte.ts";
 
 /** Auto-save every given millisecond, or never if set to `false` */
 const AUTO_SAVE_FREQUENCY: false | number = 2000;
@@ -541,22 +540,23 @@ export class ConfigStore {
     );
   }
 
-  async updateCrashReporter(value: boolean): Promise<void> {
+  async updateCrashReporter(value: boolean): Promise<string> {
     this.enableCrashReport.value = value;
+    let e = "";
     try {
       const res = await commands.sentryCrashReporterUpdate(value);
       if (res.status === "error") {
-        throw res.error;
+        e = JSON.stringify(res.error);
       }
     } catch (err) {
+      e = JSON.stringify(err);
+    }
+    if (e) {
       error(
-        `Error in changing Sentry option: ${JSON.stringify(err)}`,
-      );
-      notifier.showToast(
-        `Error in changing Sentry option: ${JSON.stringify(err)}`,
-        "error",
+        `Error in changing Sentry option: ${e}`,
       );
     }
+    return e;
   }
 }
 

--- a/src/lib/store.svelte.ts
+++ b/src/lib/store.svelte.ts
@@ -379,6 +379,7 @@ export class ConfigStore {
       error("Failed to load from store with given error: ", err);
     });
     if (oldVersion >= 0) await this.transitionDeprecatedOptions(oldVersion);
+    await this.transcriptions.load();
     this.keyChangeUnlistener = await this.fileStore.onChange((k, v) =>
       trace(`STORE CHANGE: ${k} => ${v}`)
     );
@@ -418,7 +419,6 @@ export class ConfigStore {
         await this.fileStore.delete(ConfigItem.TRANSCRIPTS);
       }
     }
-    await this.transcriptions.load();
 
     // Old Telemetry -> delete to allow app to ask again
     if (await this.fileStore.has(ConfigItem.ENABLE_TELEMETRY)) {
@@ -541,7 +541,6 @@ export class ConfigStore {
   }
 
   async updateCrashReporter(value: boolean): Promise<string> {
-    this.enableCrashReport.value = value;
     let e = "";
     try {
       const res = await commands.sentryCrashReporterUpdate(value);
@@ -555,6 +554,9 @@ export class ConfigStore {
       error(
         `Error in changing Sentry option: ${e}`,
       );
+    } else {
+      debug("Successfully changed value");
+      this.enableCrashReport.value = value;
     }
     return e;
   }

--- a/src/routes/app/+page.svelte
+++ b/src/routes/app/+page.svelte
@@ -38,7 +38,11 @@
     let menuOpen = $state(false);
     let appVersion = $state("unknown");
     let isDownloadingModel: boolean = $state(false);
-    let setupPromise: Promise<void> | undefined = $state();
+    let setupPromise: Promise<void> = $state(
+        new Promise((resolve) => {
+            resolve();
+        }),
+    );
 
     // Helper Functions
     function copyToClipboard() {
@@ -156,7 +160,13 @@
                     cancelLabel: "Opt-out",
                 },
             );
-            await configStore.updateCrashReporter(isEnabled);
+            let err = await configStore.updateCrashReporter(isEnabled);
+            if (err) {
+                notifier.showToast(
+                    `Error in changing Sentry option: ${err}`,
+                    "error",
+                );
+            }
             info("User has accepted to use the app.");
         }
         if (configStore.enableCrashReport.value) {

--- a/src/routes/app/+page.svelte
+++ b/src/routes/app/+page.svelte
@@ -169,11 +169,15 @@
             }
             info("User has accepted to use the app.");
         }
-        if (configStore.enableCrashReport.value) {
-            // TODO: Command
-            notifier.showToast("Telemetry enabled", "info", {
-                duration: 5_000,
-            });
+        if (configStore.enableCrashReport.value !== null) {
+            commands.sentryCrashReporterUpdate(
+                configStore.enableCrashReport.value,
+            );
+            if (configStore.enableCrashReport.value) {
+                notifier.showToast("Telemetry enabled", "info", {
+                    duration: 5_000,
+                });
+            }
         }
         debug("Get Version info");
         const version = await getVersion();

--- a/src/routes/app/+page.svelte
+++ b/src/routes/app/+page.svelte
@@ -27,6 +27,7 @@
         MODELS_DIR,
     } from "$lib/constants";
     import { appLocalDataDir } from "@tauri-apps/api/path";
+    import Loading from "$lib/components/ui/Loading.svelte";
 
     // Component Bindings
     let micRecorder: MicRecorder = $state() as MicRecorder;
@@ -37,6 +38,7 @@
     let menuOpen = $state(false);
     let appVersion = $state("unknown");
     let isDownloadingModel: boolean = $state(false);
+    let setupPromise: Promise<void> | undefined = $state();
 
     // Helper Functions
     function copyToClipboard() {
@@ -141,27 +143,27 @@
     async function preStartUp() {
         debug("Wait until store is loaded");
         await configStore.waitForStoreLoaded();
-        info("Show telemetry notice if not yet accepted");
-        configStore.enableTelemetry.value =
-            configStore.enableTelemetry.value ||
-            (await notifier.showDialog(
+        if (configStore.enableCrashReport.value === null) {
+            info("Show crashing notice as not yet assigned");
+            // Ask user
+            configStore.enableCrashReport.value = await notifier.showDialog(
                 "ask",
-                "We collect basic error and crash reports by default using Sentry. We DO NOT collect your private data (such as audio data or transcripts), only information related to OS (like which GPU you use) and actions that lead to the app showing an error or crashing. This cannot be turned off for pre-release builds of this app. By continuing, you agree to the terms.",
+                "We collect basic error and crash reports by default using Sentry. We DO NOT collect your private data (such as audio data or transcripts), only anonymous data related to OS (like version) and actions that lead to the app showing an error or crashing. You are free to opt-out of this collection.",
                 {
-                    kind: "warning",
-                    title: "Telemetry Notice",
-                    okLabel: "I Agree",
-                    cancelLabel: "Quit App",
+                    kind: "info",
+                    title: "Crash Report Notice",
+                    okLabel: "Opt-in",
+                    cancelLabel: "Opt-out",
                 },
-            ));
-        // TODO(before 1.0 release): Allow user to disable telemetry but still use the app
-        if (!configStore.enableTelemetry.value) {
-            // Exit immediately
-            await exit(0);
-            return;
+            );
+            info("User has accepted to use the app.");
         }
-        info("User has accepted to use the app.");
-        notifier.showToast("Telemetry enabled", "info", { duration: 5_000 });
+        if (configStore.enableCrashReport.value) {
+            // TODO: Command
+            notifier.showToast("Telemetry enabled", "info", {
+                duration: 5_000,
+            });
+        }
         debug("Get Version info");
         const version = await getVersion();
         appVersion = version.startsWith("v") ? version : `v${version}`;
@@ -222,7 +224,7 @@
 
     // Top-level clean-up ONLY (for store)
     $effect(() => {
-        preStartUp();
+        setupPromise = preStartUp();
         return () => {
             configStore.cleanup();
         };
@@ -246,7 +248,9 @@
         <h1 class="text-3xl text-center pt-12 sm:pt-0">
             SuperMouse AI ({appVersion})
         </h1>
-        {#if configStore.enableTelemetry.value}
+        {#await setupPromise}
+            <Loading color="primary" variant="infinity" size="xl" />
+        {:then _}
             <div class="flex flex-col place-content-center p-1">
                 <UpdateChecker class="mx-8" />
             </div>
@@ -311,6 +315,9 @@
                     {onError}
                 />
             </div>
-        {/if}
+        {:catch error}
+            <h2 class="text-6xl text-error">Recieved Error</h2>
+            <p>Recieved: {JSON.stringify(error)}</p>
+        {/await}
     </div>
 </main>

--- a/src/routes/app/+page.svelte
+++ b/src/routes/app/+page.svelte
@@ -146,7 +146,7 @@
         if (configStore.enableCrashReport.value === null) {
             info("Show crashing notice as not yet assigned");
             // Ask user
-            configStore.enableCrashReport.value = await notifier.showDialog(
+            const isEnabled = await notifier.showDialog(
                 "ask",
                 "We collect basic error and crash reports by default using Sentry. We DO NOT collect your private data (such as audio data or transcripts), only anonymous data related to OS (like version) and actions that lead to the app showing an error or crashing. You are free to opt-out of this collection.",
                 {
@@ -156,6 +156,7 @@
                     cancelLabel: "Opt-out",
                 },
             );
+            await configStore.updateCrashReporter(isEnabled);
             info("User has accepted to use the app.");
         }
         if (configStore.enableCrashReport.value) {


### PR DESCRIPTION
**Expected App Version Number**: `v0.8.7` (Patch)

## Pull Request Overview

- Make telemetry (crash report) optional
- User can now toggle on or off in menu
- When user is first loading app (or coming from old version), they must make a choice to accept or reject, but rejecting no longer quits the app

### Known Issues

"Currently None"

## Resolved Issues

_`N/A`_

## Additional Information

- Minidump cannot be disabled through the same Sentry config mechanism, so it is now disabled for non-debug builds.
- Technically, the events and breadcrumbs are still collected by the local Sentry runner, but if the user disables crash reports, they are immediately dropped
